### PR TITLE
Use `_tzset()` for non-POSIX Windows environments

### DIFF
--- a/lib/cbits/HsTime.c
+++ b/lib/cbits/HsTime.c
@@ -3,7 +3,17 @@
 
 long int get_current_timezone_seconds (time_t t,int* pdst,char const* * pname)
 {
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(_WIN32)
+    // When compiling with MinGW (which does not provide a full POSIX
+    // layer as opposed to CygWin) it's better to use the CRT's
+    // underscore-prefixed `_tzset()` variant to avoid linker issues
+    // as Microsoft considers the POSIX named `tzset()` function
+    // deprecated (see http://msdn.microsoft.com/en-us/library/ms235384.aspx)
+    _tzset();
+#else
     tzset();
+#endif
+
 #if HAVE_LOCALTIME_R
     struct tm tmd;
     struct tm* ptm = localtime_r(&t,&tmd);


### PR DESCRIPTION
When compiling with MinGW (which does not provide a full POSIX layer as
opposed to CygWin) it's better to use the CRT's underscore-prefixed
`_tzset()` variant to avoid linker issues as Microsoft considers the
POSIX named `tzset()` function deprecated

Further reading
- http://msdn.microsoft.com/en-us/library/ms235384.aspx
- http://stackoverflow.com/questions/23477746/what-are-the-posix-like-functions-in-msvcs-c-runtime

This hopefully addresses #2
