### PR TITLE
Add `Setup.hs` file

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Distribution.Simple
+
+main :: IO ()
+main = defaultMainWithHooks autoconfUserHooks


### PR DESCRIPTION
This adds a `Setup.hs` appropriate for `build-type: configure`
and makes `cabal check` happy.
