### PR TITLE
Added Eq and Ord instances for LocalTime.

### DIFF
--- a/lib/Data/Time/LocalTime/LocalTime.hs
+++ b/lib/Data/Time/LocalTime/LocalTime.hs
@@ -22,6 +22,7 @@ import Data.Typeable
 #if LANGUAGE_Rank2Types
 import Data.Data
 #endif
+import Data.Ord (comparing)
 
 -- | A simple day and time aggregate, where the day is of the specified parameter,
 -- and the time is a TimeOfDay.
@@ -72,13 +73,18 @@ data ZonedTime = ZonedTime {
 	zonedTimeToLocalTime :: LocalTime,
 	zonedTimeZone :: TimeZone
 }
+  deriving (Eq
 #if LANGUAGE_DeriveDataTypeable
 #if LANGUAGE_Rank2Types
 #if HAS_DataPico
-    deriving (Data, Typeable)
+    , Data, Typeable
 #endif
 #endif
 #endif
+    )
+
+instance Ord ZonedTime where
+  compare = comparing zonedTimeToUTC
 
 instance NFData ZonedTime where
 	rnf (ZonedTime lt z) = lt `deepseq` z `deepseq` ()


### PR DESCRIPTION
I couldn't get the test suite to build (circular dependencies), else I would
have verified my instances against the tests. `cabal build` works, so I figure I
couldn't have completely ruined it.

The `Eq` instance is a standard `deriving` clause. The `Ord` instance compares
the output of `zonedTimeToUTC`, using `UTCTime`'s `Ord` instance.
