### PR TITLE
Add support for `deepseq-1.4.0.0`

### DIFF
--- a/lib/Data/Time/Clock/Scale.hs
+++ b/lib/Data/Time/Clock/Scale.hs
@@ -50,7 +50,8 @@ newtype DiffTime = MkDiffTime Pico deriving (Eq,Ord
     )
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
-instance NFData DiffTime -- FIXME: Data.Fixed had no NFData instances yet at time of writing
+instance NFData DiffTime where -- FIXME: Data.Fixed had no NFData instances yet at time of writing
+        rnf dt = seq dt ()
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Enum DiffTime where

--- a/lib/Data/Time/Clock/UTC.hs
+++ b/lib/Data/Time/Clock/UTC.hs
@@ -70,7 +70,8 @@ newtype NominalDiffTime = MkNominalDiffTime Pico deriving (Eq,Ord
     )
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
-instance NFData NominalDiffTime -- FIXME: Data.Fixed had no NFData instances yet at time of writing
+instance NFData NominalDiffTime where -- FIXME: Data.Fixed had no NFData instances yet at time of writing
+        rnf ndt = seq ndt ()
 
 instance Enum NominalDiffTime where
 	succ (MkNominalDiffTime a) = MkNominalDiffTime (succ a)


### PR DESCRIPTION
`deepseq-1.4.0.0`'s major change is the default `rnf` method implementation
(see haskell/deepseq#1 for details).

This commit changes `time` not to rely on the default implementation and
instead explicitly make use of `seq` like the old default implementation did.
