### PR TITLE
Improve documentation of wdays in TimeLocale

### DIFF
--- a/lib/Data/Time/Format/Locale.hs
+++ b/lib/Data/Time/Format/Locale.hs
@@ -14,7 +14,7 @@ where
 import Data.Time.LocalTime
 
 data TimeLocale = TimeLocale {
-        -- |full and abbreviated week days
+        -- |full and abbreviated week days, starting with Sunday
         wDays  :: [(String, String)],
         -- |full and abbreviated months
         months :: [(String, String)],


### PR DESCRIPTION
From the current documentation it is not obvious that the list of day names should start with Sunday. This can cause trouble for people from cultures where Monday is considered the first day of week.
