### PR TITLE
De-tabify all Haskell source files.

### DIFF
--- a/lib/Data/Time.hs
+++ b/lib/Data/Time.hs
@@ -1,9 +1,9 @@
 module Data.Time
 (
-	module Data.Time.Calendar,
-	module Data.Time.Clock,
-	module Data.Time.LocalTime,
-	module Data.Time.Format
+    module Data.Time.Calendar,
+    module Data.Time.Clock,
+    module Data.Time.LocalTime,
+    module Data.Time.Format
 ) where
 
 import Data.Time.Calendar

--- a/lib/Data/Time/Calendar.hs
+++ b/lib/Data/Time/Calendar.hs
@@ -1,7 +1,7 @@
 module Data.Time.Calendar
 (
-	module Data.Time.Calendar.Days,
-	module Data.Time.Calendar.Gregorian
+    module Data.Time.Calendar.Days,
+    module Data.Time.Calendar.Gregorian
 ) where
 
 import Data.Time.Calendar.Days

--- a/lib/Data/Time/Calendar/Days.hs
+++ b/lib/Data/Time/Calendar/Days.hs
@@ -3,8 +3,8 @@
 -- #hide
 module Data.Time.Calendar.Days
 (
-	-- * Days
-	Day(..),addDays,diffDays
+    -- * Days
+    Day(..),addDays,diffDays
 ) where
 
 import Control.DeepSeq
@@ -24,25 +24,25 @@ newtype Day = ModifiedJulianDay {toModifiedJulianDay :: Integer} deriving (Eq,Or
     )
 
 instance NFData Day where
-	rnf (ModifiedJulianDay a) = rnf a
+    rnf (ModifiedJulianDay a) = rnf a
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Enum Day where
-	succ (ModifiedJulianDay a) = ModifiedJulianDay (succ a)
-	pred (ModifiedJulianDay a) = ModifiedJulianDay (pred a)
-	toEnum = ModifiedJulianDay . toEnum
-	fromEnum (ModifiedJulianDay a) = fromEnum a
-	enumFrom (ModifiedJulianDay a) = fmap ModifiedJulianDay (enumFrom a)
-	enumFromThen (ModifiedJulianDay a) (ModifiedJulianDay b) = fmap ModifiedJulianDay (enumFromThen a b)
-	enumFromTo (ModifiedJulianDay a) (ModifiedJulianDay b) = fmap ModifiedJulianDay (enumFromTo a b)
-	enumFromThenTo (ModifiedJulianDay a) (ModifiedJulianDay b) (ModifiedJulianDay c) = fmap ModifiedJulianDay (enumFromThenTo a b c)
+    succ (ModifiedJulianDay a) = ModifiedJulianDay (succ a)
+    pred (ModifiedJulianDay a) = ModifiedJulianDay (pred a)
+    toEnum = ModifiedJulianDay . toEnum
+    fromEnum (ModifiedJulianDay a) = fromEnum a
+    enumFrom (ModifiedJulianDay a) = fmap ModifiedJulianDay (enumFrom a)
+    enumFromThen (ModifiedJulianDay a) (ModifiedJulianDay b) = fmap ModifiedJulianDay (enumFromThen a b)
+    enumFromTo (ModifiedJulianDay a) (ModifiedJulianDay b) = fmap ModifiedJulianDay (enumFromTo a b)
+    enumFromThenTo (ModifiedJulianDay a) (ModifiedJulianDay b) (ModifiedJulianDay c) = fmap ModifiedJulianDay (enumFromThenTo a b c)
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Ix Day where
-	range (ModifiedJulianDay a,ModifiedJulianDay b) = fmap ModifiedJulianDay (range (a,b))
-	index (ModifiedJulianDay a,ModifiedJulianDay b) (ModifiedJulianDay c) = index (a,b) c
-	inRange (ModifiedJulianDay a,ModifiedJulianDay b) (ModifiedJulianDay c) = inRange (a,b) c
-	rangeSize (ModifiedJulianDay a,ModifiedJulianDay b) = rangeSize (a,b)
+    range (ModifiedJulianDay a,ModifiedJulianDay b) = fmap ModifiedJulianDay (range (a,b))
+    index (ModifiedJulianDay a,ModifiedJulianDay b) (ModifiedJulianDay c) = index (a,b) c
+    inRange (ModifiedJulianDay a,ModifiedJulianDay b) (ModifiedJulianDay c) = inRange (a,b) c
+    rangeSize (ModifiedJulianDay a,ModifiedJulianDay b) = rangeSize (a,b)
 
 addDays :: Integer -> Day -> Day
 addDays n (ModifiedJulianDay a) = ModifiedJulianDay (a + n)
@@ -52,23 +52,23 @@ diffDays (ModifiedJulianDay a) (ModifiedJulianDay b) = a - b
 
 {-
 instance Show Day where
-	show (ModifiedJulianDay d) = "MJD " ++ (show d)
+    show (ModifiedJulianDay d) = "MJD " ++ (show d)
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Num Day where
-	(ModifiedJulianDay a) + (ModifiedJulianDay b) = ModifiedJulianDay (a + b)
-	(ModifiedJulianDay a) - (ModifiedJulianDay b) = ModifiedJulianDay (a - b)
-	(ModifiedJulianDay a) * (ModifiedJulianDay b) = ModifiedJulianDay (a * b)
-	negate (ModifiedJulianDay a) = ModifiedJulianDay (negate a)
-	abs (ModifiedJulianDay a) = ModifiedJulianDay (abs a)
-	signum (ModifiedJulianDay a) = ModifiedJulianDay (signum a)
-	fromInteger = ModifiedJulianDay
+    (ModifiedJulianDay a) + (ModifiedJulianDay b) = ModifiedJulianDay (a + b)
+    (ModifiedJulianDay a) - (ModifiedJulianDay b) = ModifiedJulianDay (a - b)
+    (ModifiedJulianDay a) * (ModifiedJulianDay b) = ModifiedJulianDay (a * b)
+    negate (ModifiedJulianDay a) = ModifiedJulianDay (negate a)
+    abs (ModifiedJulianDay a) = ModifiedJulianDay (abs a)
+    signum (ModifiedJulianDay a) = ModifiedJulianDay (signum a)
+    fromInteger = ModifiedJulianDay
 
 instance Real Day where
-	toRational (ModifiedJulianDay a) = toRational a
+    toRational (ModifiedJulianDay a) = toRational a
 
 instance Integral Day where
-	toInteger (ModifiedJulianDay a) = toInteger a
-	quotRem (ModifiedJulianDay a) (ModifiedJulianDay b) = (ModifiedJulianDay c,ModifiedJulianDay d) where
-		(c,d) = quotRem a b
+    toInteger (ModifiedJulianDay a) = toInteger a
+    quotRem (ModifiedJulianDay a) (ModifiedJulianDay b) = (ModifiedJulianDay c,ModifiedJulianDay d) where
+        (c,d) = quotRem a b
 -}

--- a/lib/Data/Time/Calendar/Easter.hs
+++ b/lib/Data/Time/Calendar/Easter.hs
@@ -1,12 +1,12 @@
 module Data.Time.Calendar.Easter
-	(
-	sundayAfter,
-	orthodoxPaschalMoon,orthodoxEaster,
-	gregorianPaschalMoon,gregorianEaster
-	) where
+    (
+    sundayAfter,
+    orthodoxPaschalMoon,orthodoxEaster,
+    gregorianPaschalMoon,gregorianEaster
+    ) where
 
 -- formulae from Reingold & Dershowitz, _Calendrical Calculations_, ch. 8.
-	
+
 import Data.Time.Calendar
 import Data.Time.Calendar.Julian
 
@@ -17,8 +17,8 @@ sundayAfter day = addDays (7 - (mod (toModifiedJulianDay day + 3) 7)) day
 -- | Given a year, find the Paschal full moon according to Orthodox Christian tradition
 orthodoxPaschalMoon :: Integer -> Day
 orthodoxPaschalMoon year  = addDays (- shiftedEpact) (fromJulian jyear 4 19) where
-	shiftedEpact = mod (14 + 11 * (mod year 19)) 30
-	jyear = if year > 0 then year else year - 1
+    shiftedEpact = mod (14 + 11 * (mod year 19)) 30
+    jyear = if year > 0 then year else year - 1
 
 -- | Given a year, find Easter according to Orthodox Christian tradition
 orthodoxEaster :: Integer -> Day
@@ -27,9 +27,9 @@ orthodoxEaster = sundayAfter . orthodoxPaschalMoon
 -- | Given a year, find the Paschal full moon according to the Gregorian method
 gregorianPaschalMoon :: Integer -> Day
 gregorianPaschalMoon year  = addDays (- adjustedEpact) (fromGregorian year 4 19) where
-	century = (div year 100) + 1
-	shiftedEpact = mod (14 + 11 * (mod year 19) - (div (3 * century) 4) + (div (5 + 8 * century) 25)) 30
-	adjustedEpact = if shiftedEpact == 0 || ((shiftedEpact == 1) && (mod year 19 < 10)) then shiftedEpact + 1 else shiftedEpact
+    century = (div year 100) + 1
+    shiftedEpact = mod (14 + 11 * (mod year 19) - (div (3 * century) 4) + (div (5 + 8 * century) 25)) 30
+    adjustedEpact = if shiftedEpact == 0 || ((shiftedEpact == 1) && (mod year 19 < 10)) then shiftedEpact + 1 else shiftedEpact
 
 -- | Given a year, find Easter according to the Gregorian method
 gregorianEaster :: Integer -> Day

--- a/lib/Data/Time/Calendar/Gregorian.hs
+++ b/lib/Data/Time/Calendar/Gregorian.hs
@@ -3,16 +3,16 @@
 -- #hide
 module Data.Time.Calendar.Gregorian
 (
-	-- * Gregorian calendar
-	toGregorian,fromGregorian,fromGregorianValid,showGregorian,gregorianMonthLength,
+    -- * Gregorian calendar
+    toGregorian,fromGregorian,fromGregorianValid,showGregorian,gregorianMonthLength,
 
-	-- calendrical arithmetic
+    -- calendrical arithmetic
     -- e.g. "one month after March 31st"
-	addGregorianMonthsClip,addGregorianMonthsRollOver,
-	addGregorianYearsClip,addGregorianYearsRollOver,
+    addGregorianMonthsClip,addGregorianMonthsRollOver,
+    addGregorianYearsClip,addGregorianYearsRollOver,
 
-	-- re-exported from OrdinalDate
-	isLeapYear
+    -- re-exported from OrdinalDate
+    isLeapYear
 ) where
 
 import Data.Time.Calendar.MonthDay
@@ -23,8 +23,8 @@ import Data.Time.Calendar.Private
 -- | convert to proleptic Gregorian calendar. First element of result is year, second month number (1-12), third day (1-31).
 toGregorian :: Day -> (Integer,Int,Int)
 toGregorian date = (year,month,day) where
-	(year,yd) = toOrdinalDate date
-	(month,day) = dayOfYearToMonthAndDay (isLeapYear year) yd
+    (year,yd) = toOrdinalDate date
+    (month,day) = dayOfYearToMonthAndDay (isLeapYear year) yd
 
 -- | convert from proleptic Gregorian calendar. First argument is year, second month number (1-12), third day (1-31).
 -- Invalid values will be clipped to the correct range, month first, then day.
@@ -35,13 +35,13 @@ fromGregorian year month day = fromOrdinalDate year (monthAndDayToDayOfYear (isL
 -- Invalid values will return Nothing
 fromGregorianValid :: Integer -> Int -> Int -> Maybe Day
 fromGregorianValid year month day = do
-	doy <- monthAndDayToDayOfYearValid (isLeapYear year) month day
-	fromOrdinalDateValid year doy
+    doy <- monthAndDayToDayOfYearValid (isLeapYear year) month day
+    fromOrdinalDateValid year doy
 
 -- | show in ISO 8601 format (yyyy-mm-dd)
 showGregorian :: Day -> String
 showGregorian date = (show4 (Just '0') y) ++ "-" ++ (show2 (Just '0') m) ++ "-" ++ (show2 (Just '0') d) where
-	(y,m,d) = toGregorian date
+    (y,m,d) = toGregorian date
 
 -- | The number of days in a given month according to the proleptic Gregorian calendar. First argument is year, second is month.
 gregorianMonthLength :: Integer -> Int -> Int
@@ -52,20 +52,20 @@ rolloverMonths (y,m) = (y + (div (m - 1) 12),fromIntegral (mod (m - 1) 12) + 1)
 
 addGregorianMonths :: Integer -> Day -> (Integer,Int,Int)
 addGregorianMonths n day = (y',m',d) where
-	(y,m,d) = toGregorian day
-	(y',m') = rolloverMonths (y,fromIntegral m + n)
+    (y,m,d) = toGregorian day
+    (y',m') = rolloverMonths (y,fromIntegral m + n)
 
 -- | Add months, with days past the last day of the month clipped to the last day.
 -- For instance, 2005-01-30 + 1 month = 2005-02-28.
 addGregorianMonthsClip :: Integer -> Day -> Day
 addGregorianMonthsClip n day = fromGregorian y m d where
-	(y,m,d) = addGregorianMonths n day
+    (y,m,d) = addGregorianMonths n day
 
 -- | Add months, with days past the last day of the month rolling over to the next month.
 -- For instance, 2005-01-30 + 1 month = 2005-03-02.
 addGregorianMonthsRollOver :: Integer -> Day -> Day
 addGregorianMonthsRollOver n day = addDays (fromIntegral d - 1) (fromGregorian y m 1) where
-	(y,m,d) = addGregorianMonths n day
+    (y,m,d) = addGregorianMonths n day
 
 -- | Add years, matching month and day, with Feb 29th clipped to Feb 28th if necessary.
 -- For instance, 2004-02-29 + 2 years = 2006-02-28.
@@ -79,4 +79,4 @@ addGregorianYearsRollOver n = addGregorianMonthsRollOver (n * 12)
 
 -- orphan instance
 instance Show Day where
-	show = showGregorian
+    show = showGregorian

--- a/lib/Data/Time/Calendar/Julian.hs
+++ b/lib/Data/Time/Calendar/Julian.hs
@@ -1,13 +1,13 @@
 module Data.Time.Calendar.Julian
 (
-	module Data.Time.Calendar.JulianYearDay,
+    module Data.Time.Calendar.JulianYearDay,
 
-	toJulian,fromJulian,fromJulianValid,showJulian,julianMonthLength,
+    toJulian,fromJulian,fromJulianValid,showJulian,julianMonthLength,
 
-	-- calendrical arithmetic
+    -- calendrical arithmetic
     -- e.g. "one month after March 31st"
-	addJulianMonthsClip,addJulianMonthsRollOver,
-	addJulianYearsClip,addJulianYearsRollOver
+    addJulianMonthsClip,addJulianMonthsRollOver,
+    addJulianYearsClip,addJulianYearsRollOver
 ) where
 
 import Data.Time.Calendar.MonthDay
@@ -18,8 +18,8 @@ import Data.Time.Calendar.Private
 -- | convert to proleptic Julian calendar. First element of result is year, second month number (1-12), third day (1-31).
 toJulian :: Day -> (Integer,Int,Int)
 toJulian date = (year,month,day) where
-	(year,yd) = toJulianYearAndDay date
-	(month,day) = dayOfYearToMonthAndDay (isJulianLeapYear year) yd
+    (year,yd) = toJulianYearAndDay date
+    (month,day) = dayOfYearToMonthAndDay (isJulianLeapYear year) yd
 
 -- | convert from proleptic Julian calendar. First argument is year, second month number (1-12), third day (1-31).
 -- Invalid values will be clipped to the correct range, month first, then day.
@@ -30,13 +30,13 @@ fromJulian year month day = fromJulianYearAndDay year (monthAndDayToDayOfYear (i
 -- Invalid values will return Nothing.
 fromJulianValid :: Integer -> Int -> Int -> Maybe Day
 fromJulianValid year month day = do
-	doy <- monthAndDayToDayOfYearValid (isJulianLeapYear year) month day
-	fromJulianYearAndDayValid year doy
+    doy <- monthAndDayToDayOfYearValid (isJulianLeapYear year) month day
+    fromJulianYearAndDayValid year doy
 
 -- | show in ISO 8601 format (yyyy-mm-dd)
 showJulian :: Day -> String
 showJulian date = (show4 (Just '0') y) ++ "-" ++ (show2 (Just '0') m) ++ "-" ++ (show2 (Just '0') d) where
-	(y,m,d) = toJulian date
+    (y,m,d) = toJulian date
 
 -- | The number of days in a given month according to the proleptic Julian calendar. First argument is year, second is month.
 julianMonthLength :: Integer -> Int -> Int
@@ -47,20 +47,20 @@ rolloverMonths (y,m) = (y + (div (m - 1) 12),fromIntegral (mod (m - 1) 12) + 1)
 
 addJulianMonths :: Integer -> Day -> (Integer,Int,Int)
 addJulianMonths n day = (y',m',d) where
-	(y,m,d) = toJulian day
-	(y',m') = rolloverMonths (y,fromIntegral m + n)
+    (y,m,d) = toJulian day
+    (y',m') = rolloverMonths (y,fromIntegral m + n)
 
 -- | Add months, with days past the last day of the month clipped to the last day.
 -- For instance, 2005-01-30 + 1 month = 2005-02-28.
 addJulianMonthsClip :: Integer -> Day -> Day
 addJulianMonthsClip n day = fromJulian y m d where
-	(y,m,d) = addJulianMonths n day
+    (y,m,d) = addJulianMonths n day
 
 -- | Add months, with days past the last day of the month rolling over to the next month.
 -- For instance, 2005-01-30 + 1 month = 2005-03-02.
 addJulianMonthsRollOver :: Integer -> Day -> Day
 addJulianMonthsRollOver n day = addDays (fromIntegral d - 1) (fromJulian y m 1) where
-	(y,m,d) = addJulianMonths n day
+    (y,m,d) = addJulianMonths n day
 
 -- | Add years, matching month and day, with Feb 29th clipped to Feb 28th if necessary.
 -- For instance, 2004-02-29 + 2 years = 2006-02-28.

--- a/lib/Data/Time/Calendar/JulianYearDay.hs
+++ b/lib/Data/Time/Calendar/JulianYearDay.hs
@@ -1,9 +1,9 @@
 -- #hide
 module Data.Time.Calendar.JulianYearDay
-	(
-	-- * Year and day format
-	module Data.Time.Calendar.JulianYearDay
-	) where
+    (
+    -- * Year and day format
+    module Data.Time.Calendar.JulianYearDay
+    ) where
 
 import Data.Time.Calendar.Days
 import Data.Time.Calendar.Private
@@ -12,34 +12,34 @@ import Data.Time.Calendar.Private
 -- second is the day of the year, with 1 for Jan 1, and 365 (or 366 in leap years) for Dec 31.
 toJulianYearAndDay :: Day -> (Integer,Int)
 toJulianYearAndDay (ModifiedJulianDay mjd) = (year,yd) where
-	a = mjd + 678577
-	quad = div a 1461
-	d = mod a 1461
-	y = min (div d 365) 3
-	yd = fromInteger (d - (y * 365) + 1)
-	year = quad * 4 + y + 1
+    a = mjd + 678577
+    quad = div a 1461
+    d = mod a 1461
+    y = min (div d 365) 3
+    yd = fromInteger (d - (y * 365) + 1)
+    year = quad * 4 + y + 1
 
 -- | convert from proleptic Julian year and day format.
 -- Invalid day numbers will be clipped to the correct range (1 to 365 or 366).
 fromJulianYearAndDay :: Integer -> Int -> Day
 fromJulianYearAndDay year day = ModifiedJulianDay mjd where
-	y = year - 1
-	mjd = (fromIntegral (clip 1 (if isJulianLeapYear year then 366 else 365) day)) + (365 * y) + (div y 4) - 678578
+    y = year - 1
+    mjd = (fromIntegral (clip 1 (if isJulianLeapYear year then 366 else 365) day)) + (365 * y) + (div y 4) - 678578
 
 -- | convert from proleptic Julian year and day format.
 -- Invalid day numbers will return Nothing
 fromJulianYearAndDayValid :: Integer -> Int -> Maybe Day
 fromJulianYearAndDayValid year day = do
-	day' <- clipValid 1 (if isJulianLeapYear year then 366 else 365) day
-	let
-		y = year - 1
-		mjd = (fromIntegral day') + (365 * y) + (div y 4) - 678578
-	return (ModifiedJulianDay mjd)
+    day' <- clipValid 1 (if isJulianLeapYear year then 366 else 365) day
+    let
+        y = year - 1
+        mjd = (fromIntegral day') + (365 * y) + (div y 4) - 678578
+    return (ModifiedJulianDay mjd)
 
 -- | show in proleptic Julian year and day format (yyyy-ddd)
 showJulianYearAndDay :: Day -> String
 showJulianYearAndDay date = (show4 (Just '0') y) ++ "-" ++ (show3 (Just '0') d) where
-	(y,d) = toJulianYearAndDay date
+    (y,d) = toJulianYearAndDay date
 
 -- | Is this year a leap year according to the proleptic Julian calendar?
 isJulianLeapYear :: Integer -> Bool

--- a/lib/Data/Time/Calendar/MonthDay.hs
+++ b/lib/Data/Time/Calendar/MonthDay.hs
@@ -1,7 +1,7 @@
 module Data.Time.Calendar.MonthDay
-	(
-	monthAndDayToDayOfYear,monthAndDayToDayOfYearValid,dayOfYearToMonthAndDay,monthLength
-	) where
+    (
+    monthAndDayToDayOfYear,monthAndDayToDayOfYearValid,dayOfYearToMonthAndDay,monthLength
+    ) where
 
 import Data.Time.Calendar.Private
 
@@ -9,22 +9,22 @@ import Data.Time.Calendar.Private
 -- First arg is leap year flag
 monthAndDayToDayOfYear :: Bool -> Int -> Int -> Int
 monthAndDayToDayOfYear isLeap month day = (div (367 * month'' - 362) 12) + k + day' where
-	month' = clip 1 12 month
-	day' = fromIntegral (clip 1 (monthLength' isLeap month') day)
-	month'' = fromIntegral month'
-	k = if month' <= 2 then 0 else if isLeap then -1 else -2
+    month' = clip 1 12 month
+    day' = fromIntegral (clip 1 (monthLength' isLeap month') day)
+    month'' = fromIntegral month'
+    k = if month' <= 2 then 0 else if isLeap then -1 else -2
 
 -- | convert month and day in the Gregorian or Julian calendars to day of year.
 -- First arg is leap year flag
 monthAndDayToDayOfYearValid :: Bool -> Int -> Int -> Maybe Int
 monthAndDayToDayOfYearValid isLeap month day = do
-	month' <- clipValid 1 12 month
-	day' <- clipValid 1 (monthLength' isLeap month') day
-	let
-		day'' = fromIntegral day'
-		month'' = fromIntegral month'
-		k = if month' <= 2 then 0 else if isLeap then -1 else -2
-	return ((div (367 * month'' - 362) 12) + k + day'')
+    month' <- clipValid 1 12 month
+    day' <- clipValid 1 (monthLength' isLeap month') day
+    let
+        day'' = fromIntegral day'
+        month'' = fromIntegral month'
+        k = if month' <= 2 then 0 else if isLeap then -1 else -2
+    return ((div (367 * month'' - 362) 12) + k + day'')
 
 -- | convert day of year in the Gregorian or Julian calendars to month and day.
 -- First arg is leap year flag
@@ -44,6 +44,6 @@ monthLength' :: Bool -> Int -> Int
 monthLength' isLeap month' = (monthLengths isLeap) !! (month' - 1)
 
 monthLengths :: Bool -> [Int]
-monthLengths isleap = 
-	[31,if isleap then 29 else 28,31,30,31,30,31,31,30,31,30,31]
-	--J        F                   M  A  M  J  J  A  S  O  N  D
+monthLengths isleap =
+    [31,if isleap then 29 else 28,31,30,31,30,31,31,30,31,30,31]
+    --J        F                   M  A  M  J  J  A  S  O  N  D

--- a/lib/Data/Time/Calendar/OrdinalDate.hs
+++ b/lib/Data/Time/Calendar/OrdinalDate.hs
@@ -8,38 +8,38 @@ import Data.Time.Calendar.Private
 -- second is the day of the year, with 1 for Jan 1, and 365 (or 366 in leap years) for Dec 31.
 toOrdinalDate :: Day -> (Integer,Int)
 toOrdinalDate (ModifiedJulianDay mjd) = (year,yd) where
-	a = mjd + 678575
-	quadcent = div a 146097
-	b = mod a 146097
-	cent = min (div b 36524) 3
-	c = b - (cent * 36524)
-	quad = div c 1461
-	d = mod c 1461
-	y = min (div d 365) 3
-	yd = fromInteger (d - (y * 365) + 1)
-	year = quadcent * 400 + cent * 100 + quad * 4 + y + 1
+    a = mjd + 678575
+    quadcent = div a 146097
+    b = mod a 146097
+    cent = min (div b 36524) 3
+    c = b - (cent * 36524)
+    quad = div c 1461
+    d = mod c 1461
+    y = min (div d 365) 3
+    yd = fromInteger (d - (y * 365) + 1)
+    year = quadcent * 400 + cent * 100 + quad * 4 + y + 1
 
 -- | convert from ISO 8601 Ordinal Date format.
 -- Invalid day numbers will be clipped to the correct range (1 to 365 or 366).
 fromOrdinalDate :: Integer -> Int -> Day
 fromOrdinalDate year day = ModifiedJulianDay mjd where
-	y = year - 1
-	mjd = (fromIntegral (clip 1 (if isLeapYear year then 366 else 365) day)) + (365 * y) + (div y 4) - (div y 100) + (div y 400) - 678576
+    y = year - 1
+    mjd = (fromIntegral (clip 1 (if isLeapYear year then 366 else 365) day)) + (365 * y) + (div y 4) - (div y 100) + (div y 400) - 678576
 
 -- | convert from ISO 8601 Ordinal Date format.
 -- Invalid day numbers return Nothing
 fromOrdinalDateValid :: Integer -> Int -> Maybe Day
 fromOrdinalDateValid year day = do
-	day' <- clipValid 1 (if isLeapYear year then 366 else 365) day
-	let
-		y = year - 1
-		mjd = (fromIntegral day') + (365 * y) + (div y 4) - (div y 100) + (div y 400) - 678576
-	return (ModifiedJulianDay mjd)
+    day' <- clipValid 1 (if isLeapYear year then 366 else 365) day
+    let
+        y = year - 1
+        mjd = (fromIntegral day') + (365 * y) + (div y 4) - (div y 100) + (div y 400) - 678576
+    return (ModifiedJulianDay mjd)
 
 -- | show in ISO 8601 Ordinal Date format (yyyy-ddd)
 showOrdinalDate :: Day -> String
 showOrdinalDate date = (show4 (Just '0') y) ++ "-" ++ (show3 (Just '0') d) where
-	(y,d) = toOrdinalDate date
+    (y,d) = toOrdinalDate date
 
 -- | Is this year a leap year according to the proleptic Gregorian calendar?
 isLeapYear :: Integer -> Bool
@@ -50,26 +50,26 @@ isLeapYear year = (mod year 4 == 0) && ((mod year 400 == 0) || not (mod year 100
 -- Monday is 1, Sunday is 7 (as \"%u\" in 'Data.Time.Format.formatTime').
 mondayStartWeek :: Day -> (Int,Int)
 mondayStartWeek date = (fromInteger ((div d 7) - (div k 7)),fromInteger (mod d 7) + 1) where
-	yd = snd (toOrdinalDate date)
-	d = (toModifiedJulianDay date) + 2
-	k = d - (toInteger yd)
+    yd = snd (toOrdinalDate date)
+    d = (toModifiedJulianDay date) + 2
+    k = d - (toInteger yd)
 
 -- | Get the number of the Sunday-starting week in the year and the day of the week.
 -- The first Sunday is the first day of week 1, any earlier days in the year are week 0 (as \"%U\" in 'Data.Time.Format.formatTime').
 -- Sunday is 0, Saturday is 6 (as \"%w\" in 'Data.Time.Format.formatTime').
 sundayStartWeek :: Day -> (Int,Int)
 sundayStartWeek date =(fromInteger ((div d 7) - (div k 7)),fromInteger (mod d 7)) where
-	yd = snd (toOrdinalDate date)
-	d = (toModifiedJulianDay date) + 3
-	k = d - (toInteger yd)
+    yd = snd (toOrdinalDate date)
+    d = (toModifiedJulianDay date) + 3
+    k = d - (toInteger yd)
 
 -- | The inverse of 'mondayStartWeek'. Get a 'Day' given the year,
 -- the number of the Monday-starting week, and the day of the week.
--- The first Monday is the first day of week 1, any earlier days in the year 
+-- The first Monday is the first day of week 1, any earlier days in the year
 -- are week 0 (as \"%W\" in 'Data.Time.Format.formatTime').
 fromMondayStartWeek :: Integer -- ^ Year.
                     -> Int     -- ^ Monday-starting week number.
-                    -> Int     -- ^ Day of week. 
+                    -> Int     -- ^ Day of week.
                                -- Monday is 1, Sunday is 7 (as \"%u\" in 'Data.Time.Format.formatTime').
                     -> Day
 fromMondayStartWeek y w d = ModifiedJulianDay (firstDay + yd)
@@ -81,22 +81,22 @@ fromMondayStartWeek y w d = ModifiedJulianDay (firstDay + yd)
 
 fromMondayStartWeekValid :: Integer -- ^ Year.
                     -> Int     -- ^ Monday-starting week number.
-                    -> Int     -- ^ Day of week. 
+                    -> Int     -- ^ Day of week.
                                -- Monday is 1, Sunday is 7 (as \"%u\" in 'Data.Time.Format.formatTime').
                     -> Maybe Day
 fromMondayStartWeekValid year w d = do
-	d' <- clipValid 1 7 d
-	-- first day of the year
-	let firstDay = toModifiedJulianDay (fromOrdinalDate year 1)
-	-- 0-based year day of first monday of the year
-	let firstMonday = (5 - firstDay) `mod` 7
-	let yd = firstMonday + 7 * toInteger (w-1) + toInteger d'
-	yd' <- clipValid 1 (if isLeapYear year then 366 else 365) yd
-	return (ModifiedJulianDay (firstDay - 1 + yd'))
+    d' <- clipValid 1 7 d
+    -- first day of the year
+    let firstDay = toModifiedJulianDay (fromOrdinalDate year 1)
+    -- 0-based year day of first monday of the year
+    let firstMonday = (5 - firstDay) `mod` 7
+    let yd = firstMonday + 7 * toInteger (w-1) + toInteger d'
+    yd' <- clipValid 1 (if isLeapYear year then 366 else 365) yd
+    return (ModifiedJulianDay (firstDay - 1 + yd'))
 
 -- | The inverse of 'sundayStartWeek'. Get a 'Day' given the year and
 -- the number of the day of a Sunday-starting week.
--- The first Sunday is the first day of week 1, any earlier days in the 
+-- The first Sunday is the first day of week 1, any earlier days in the
 -- year are week 0 (as \"%U\" in 'Data.Time.Format.formatTime').
 fromSundayStartWeek :: Integer -- ^ Year.
                     -> Int     -- ^ Sunday-starting week number.
@@ -112,16 +112,16 @@ fromSundayStartWeek y w d = ModifiedJulianDay (firstDay + yd)
 
 fromSundayStartWeekValid :: Integer -- ^ Year.
                     -> Int     -- ^ Monday-starting week number.
-                    -> Int     -- ^ Day of week. 
+                    -> Int     -- ^ Day of week.
                                -- Monday is 1, Sunday is 7 (as \"%u\" in 'Data.Time.Format.formatTime').
                     -> Maybe Day
 fromSundayStartWeekValid year w d = do
-	d' <- clipValid 1 7 d
-	-- first day of the year
-	let firstDay = toModifiedJulianDay (fromOrdinalDate year 1)
-	-- 0-based year day of first sunday of the year
-	let firstMonday = (4 - firstDay) `mod` 7
-	let yd = firstMonday + 7 * toInteger (w-1) + toInteger d'
-	yd' <- clipValid 1 (if isLeapYear year then 366 else 365) yd
-	return (ModifiedJulianDay (firstDay - 1 + yd'))
+    d' <- clipValid 1 7 d
+    -- first day of the year
+    let firstDay = toModifiedJulianDay (fromOrdinalDate year 1)
+    -- 0-based year day of first sunday of the year
+    let firstMonday = (4 - firstDay) `mod` 7
+    let yd = firstMonday + 7 * toInteger (w-1) + toInteger d'
+    yd' <- clipValid 1 (if isLeapYear year then 366 else 365) yd
+    return (ModifiedJulianDay (firstDay - 1 + yd'))
 

--- a/lib/Data/Time/Calendar/WeekDate.hs
+++ b/lib/Data/Time/Calendar/WeekDate.hs
@@ -10,43 +10,43 @@ import Data.Time.Calendar.Private
 -- The first week of a year is the first week to contain at least four days in the corresponding Gregorian year.
 toWeekDate :: Day -> (Integer,Int,Int)
 toWeekDate date@(ModifiedJulianDay mjd) = (y1,fromInteger (w1 + 1),fromInteger d_mod_7 + 1) where
-        (d_div_7, d_mod_7) = d `divMod` 7
-	(y0,yd) = toOrdinalDate date
-	d = mjd + 2
-	foo :: Integer -> Integer
-	foo y = bar (toModifiedJulianDay (fromOrdinalDate y 6))
-	bar k = d_div_7 - k `div` 7
-	(y1,w1) = case bar (d - toInteger yd + 4) of
-	            -1 -> (y0 - 1, foo (y0 - 1))
-	            52 -> if foo (y0 + 1) == 0
-	                  then (y0 + 1, 0)
-	                  else (y0, 52)
-	            w0  -> (y0, w0)
-	
+    (d_div_7, d_mod_7) = d `divMod` 7
+    (y0,yd) = toOrdinalDate date
+    d = mjd + 2
+    foo :: Integer -> Integer
+    foo y = bar (toModifiedJulianDay (fromOrdinalDate y 6))
+    bar k = d_div_7 - k `div` 7
+    (y1,w1) = case bar (d - toInteger yd + 4) of
+                -1 -> (y0 - 1, foo (y0 - 1))
+                52 -> if foo (y0 + 1) == 0
+                      then (y0 + 1, 0)
+                      else (y0, 52)
+                w0  -> (y0, w0)
+
 -- | convert from ISO 8601 Week Date format. First argument is year, second week number (1-52 or 53), third day of week (1 for Monday to 7 for Sunday).
 -- Invalid week and day values will be clipped to the correct range.
 fromWeekDate :: Integer -> Int -> Int -> Day
 fromWeekDate y w d = ModifiedJulianDay (k - (mod k 7) + (toInteger (((clip 1 (if longYear then 53 else 52) w) * 7) + (clip 1 7 d))) - 10) where
-		k = toModifiedJulianDay (fromOrdinalDate y 6)
-		longYear = case toWeekDate (fromOrdinalDate y 365) of
-			(_,53,_) -> True
-			_ -> False
+        k = toModifiedJulianDay (fromOrdinalDate y 6)
+        longYear = case toWeekDate (fromOrdinalDate y 365) of
+            (_,53,_) -> True
+            _ -> False
 
 -- | convert from ISO 8601 Week Date format. First argument is year, second week number (1-52 or 53), third day of week (1 for Monday to 7 for Sunday).
 -- Invalid week and day values will return Nothing.
 fromWeekDateValid :: Integer -> Int -> Int -> Maybe Day
 fromWeekDateValid y w d = do
-	d' <- clipValid 1 7 d
-	let
-		longYear = case toWeekDate (fromOrdinalDate y 365) of
-			(_,53,_) -> True
-			_ -> False
-	w' <- clipValid 1 (if longYear then 53 else 52) w
-	let
-		k = toModifiedJulianDay (fromOrdinalDate y 6)
-	return (ModifiedJulianDay (k - (mod k 7) + (toInteger ((w' * 7) + d')) - 10))
+    d' <- clipValid 1 7 d
+    let
+        longYear = case toWeekDate (fromOrdinalDate y 365) of
+            (_,53,_) -> True
+            _ -> False
+    w' <- clipValid 1 (if longYear then 53 else 52) w
+    let
+        k = toModifiedJulianDay (fromOrdinalDate y 6)
+    return (ModifiedJulianDay (k - (mod k 7) + (toInteger ((w' * 7) + d')) - 10))
 
 -- | show in ISO 8601 Week Date format as yyyy-Www-d (e.g. \"2006-W46-3\").
 showWeekDate :: Day -> String
 showWeekDate date = (show4 (Just '0') y) ++ "-W" ++ (show2 (Just '0') w) ++ "-" ++ (show d) where
-	(y,w,d) = toWeekDate date
+    (y,w,d) = toWeekDate date

--- a/lib/Data/Time/Clock.hs
+++ b/lib/Data/Time/Clock.hs
@@ -1,10 +1,10 @@
 -- | Types and functions for UTC and UT1
 module Data.Time.Clock
 (
-	module Data.Time.Clock.Scale,
-	module Data.Time.Clock.UTC,
-	module Data.Time.Clock.UTCDiff,
-	module Data.Time.Clock
+    module Data.Time.Clock.Scale,
+    module Data.Time.Clock.UTC,
+    module Data.Time.Clock.UTCDiff,
+    module Data.Time.Clock
 ) where
 
 import Data.Time.Clock.Scale

--- a/lib/Data/Time/Clock/CTimeval.hs
+++ b/lib/Data/Time/Clock/CTimeval.hs
@@ -14,23 +14,23 @@ import Foreign.C
 data CTimeval = MkCTimeval CLong CLong
 
 instance Storable CTimeval where
-	sizeOf _ = (sizeOf (undefined :: CLong)) * 2
-	alignment _ = alignment (undefined :: CLong)
-	peek p = do
-		s   <- peekElemOff (castPtr p) 0
-		mus <- peekElemOff (castPtr p) 1
-		return (MkCTimeval s mus)
-	poke p (MkCTimeval s mus) = do
-		pokeElemOff (castPtr p) 0 s
-		pokeElemOff (castPtr p) 1 mus
+    sizeOf _ = (sizeOf (undefined :: CLong)) * 2
+    alignment _ = alignment (undefined :: CLong)
+    peek p = do
+        s   <- peekElemOff (castPtr p) 0
+        mus <- peekElemOff (castPtr p) 1
+        return (MkCTimeval s mus)
+    poke p (MkCTimeval s mus) = do
+        pokeElemOff (castPtr p) 0 s
+        pokeElemOff (castPtr p) 1 mus
 
 foreign import ccall unsafe "time.h gettimeofday" gettimeofday :: Ptr CTimeval -> Ptr () -> IO CInt
 
 -- | Get the current POSIX time from the system clock.
 getCTimeval :: IO CTimeval
 getCTimeval = with (MkCTimeval 0 0) (\ptval -> do
-	throwErrnoIfMinus1_ "gettimeofday" $ gettimeofday ptval nullPtr
-	peek ptval
-	)
+    throwErrnoIfMinus1_ "gettimeofday" $ gettimeofday ptval nullPtr
+    peek ptval
+    )
 
 #endif

--- a/lib/Data/Time/Clock/POSIX.hs
+++ b/lib/Data/Time/Clock/POSIX.hs
@@ -2,7 +2,7 @@
 -- Most people won't need this module.
 module Data.Time.Clock.POSIX
 (
-	posixDayLength,POSIXTime,posixSecondsToUTCTime,utcTimeToPOSIXSeconds,getPOSIXTime
+    posixDayLength,POSIXTime,posixSecondsToUTCTime,utcTimeToPOSIXSeconds,getPOSIXTime
 ) where
 
 import Data.Time.Clock.UTC
@@ -11,7 +11,7 @@ import Data.Fixed
 import Control.Monad
 
 #ifdef mingw32_HOST_OS
-import Data.Word	( Word64)
+import Data.Word    ( Word64)
 import System.Win32.Time
 #else
 import Data.Time.Clock.CTimeval
@@ -22,7 +22,7 @@ posixDayLength :: NominalDiffTime
 posixDayLength = 86400
 
 -- | POSIX time is the nominal time since 1970-01-01 00:00 UTC
--- 
+--
 -- To convert from a 'Foreign.C.CTime' or 'System.Posix.EpochTime', use 'realToFrac'.
 --
 type POSIXTime = NominalDiffTime
@@ -32,7 +32,7 @@ unixEpochDay = ModifiedJulianDay 40587
 
 posixSecondsToUTCTime :: POSIXTime -> UTCTime
 posixSecondsToUTCTime i = let
-	(d,t) = divMod' i posixDayLength
+    (d,t) = divMod' i posixDayLength
  in UTCTime (addDays d unixEpochDay) (realToFrac t)
 
 utcTimeToPOSIXSeconds :: UTCTime -> POSIXTime

--- a/lib/Data/Time/Clock/Scale.hs
+++ b/lib/Data/Time/Clock/Scale.hs
@@ -4,12 +4,12 @@
 -- #hide
 module Data.Time.Clock.Scale
 (
-	-- * Universal Time
-	-- | Time as measured by the earth.
-	UniversalTime(..),
+    -- * Universal Time
+    -- | Time as measured by the earth.
+    UniversalTime(..),
 
-	-- * Absolute intervals
-	DiffTime,
+    -- * Absolute intervals
+    DiffTime,
         secondsToDiffTime, picosecondsToDiffTime
 ) where
 
@@ -33,7 +33,7 @@ newtype UniversalTime = ModJulianDate {getModJulianDate :: Rational} deriving (E
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance NFData UniversalTime where
-	rnf (ModJulianDate a) = rnf a
+    rnf (ModJulianDate a) = rnf a
 
 -- | This is a length of time, as measured by a clock.
 -- Conversion functions will treat it as seconds.
@@ -55,37 +55,37 @@ instance NFData DiffTime where -- FIXME: Data.Fixed had no NFData instances yet 
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Enum DiffTime where
-	succ (MkDiffTime a) = MkDiffTime (succ a)
-	pred (MkDiffTime a) = MkDiffTime (pred a)
-	toEnum = MkDiffTime . toEnum
-	fromEnum (MkDiffTime a) = fromEnum a
-	enumFrom (MkDiffTime a) = fmap MkDiffTime (enumFrom a)
-	enumFromThen (MkDiffTime a) (MkDiffTime b) = fmap MkDiffTime (enumFromThen a b)
-	enumFromTo (MkDiffTime a) (MkDiffTime b) = fmap MkDiffTime (enumFromTo a b)
-	enumFromThenTo (MkDiffTime a) (MkDiffTime b) (MkDiffTime c) = fmap MkDiffTime (enumFromThenTo a b c)
+    succ (MkDiffTime a) = MkDiffTime (succ a)
+    pred (MkDiffTime a) = MkDiffTime (pred a)
+    toEnum = MkDiffTime . toEnum
+    fromEnum (MkDiffTime a) = fromEnum a
+    enumFrom (MkDiffTime a) = fmap MkDiffTime (enumFrom a)
+    enumFromThen (MkDiffTime a) (MkDiffTime b) = fmap MkDiffTime (enumFromThen a b)
+    enumFromTo (MkDiffTime a) (MkDiffTime b) = fmap MkDiffTime (enumFromTo a b)
+    enumFromThenTo (MkDiffTime a) (MkDiffTime b) (MkDiffTime c) = fmap MkDiffTime (enumFromThenTo a b c)
 
 instance Show DiffTime where
-	show (MkDiffTime t) = (showFixed True t) ++ "s"
+    show (MkDiffTime t) = (showFixed True t) ++ "s"
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Num DiffTime where
-	(MkDiffTime a) + (MkDiffTime b) = MkDiffTime (a + b)
-	(MkDiffTime a) - (MkDiffTime b) = MkDiffTime (a - b)
-	(MkDiffTime a) * (MkDiffTime b) = MkDiffTime (a * b)
-	negate (MkDiffTime a) = MkDiffTime (negate a)
-	abs (MkDiffTime a) = MkDiffTime (abs a)
-	signum (MkDiffTime a) = MkDiffTime (signum a)
-	fromInteger i = MkDiffTime (fromInteger i)
+    (MkDiffTime a) + (MkDiffTime b) = MkDiffTime (a + b)
+    (MkDiffTime a) - (MkDiffTime b) = MkDiffTime (a - b)
+    (MkDiffTime a) * (MkDiffTime b) = MkDiffTime (a * b)
+    negate (MkDiffTime a) = MkDiffTime (negate a)
+    abs (MkDiffTime a) = MkDiffTime (abs a)
+    signum (MkDiffTime a) = MkDiffTime (signum a)
+    fromInteger i = MkDiffTime (fromInteger i)
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Real DiffTime where
-	toRational (MkDiffTime a) = toRational a
+    toRational (MkDiffTime a) = toRational a
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Fractional DiffTime where
-	(MkDiffTime a) / (MkDiffTime b) = MkDiffTime (a / b)
-	recip (MkDiffTime a) = MkDiffTime (recip a)
-	fromRational r = MkDiffTime (fromRational r)
+    (MkDiffTime a) / (MkDiffTime b) = MkDiffTime (a / b)
+    recip (MkDiffTime a) = MkDiffTime (recip a)
+    fromRational r = MkDiffTime (fromRational r)
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance RealFrac DiffTime where

--- a/lib/Data/Time/Clock/TAI.hs
+++ b/lib/Data/Time/Clock/TAI.hs
@@ -3,16 +3,16 @@
 -- | TAI and leap-second tables for converting to UTC: most people won't need this module.
 module Data.Time.Clock.TAI
 (
-	-- TAI arithmetic
-	AbsoluteTime,taiEpoch,addAbsoluteTime,diffAbsoluteTime,
+    -- TAI arithmetic
+    AbsoluteTime,taiEpoch,addAbsoluteTime,diffAbsoluteTime,
 
-	-- leap-second table type
-	LeapSecondTable,
+    -- leap-second table type
+    LeapSecondTable,
 
-	-- conversion between UTC and TAI with table
-	utcDayLength,utcToTAITime,taiToUTCTime,
+    -- conversion between UTC and TAI with table
+    utcDayLength,utcToTAITime,taiToUTCTime,
 
-	parseTAIUTCDATFile
+    parseTAIUTCDATFile
 ) where
 
 import Data.Time.LocalTime
@@ -37,10 +37,10 @@ newtype AbsoluteTime = MkAbsoluteTime {unAbsoluteTime :: DiffTime} deriving (Eq,
     )
 
 instance NFData AbsoluteTime where
-	rnf (MkAbsoluteTime a) = rnf a
+    rnf (MkAbsoluteTime a) = rnf a
 
 instance Show AbsoluteTime where
-	show t = show (utcToLocalTime utc (taiToUTCTime (const 0) t)) ++ " TAI" -- ugly, but standard apparently
+    show t = show (utcToLocalTime utc (taiToUTCTime (const 0) t)) ++ " TAI" -- ugly, but standard apparently
 
 -- | The epoch of TAI, which is 1858-11-17 00:00:00 TAI.
 taiEpoch :: AbsoluteTime
@@ -63,80 +63,80 @@ utcDayLength :: LeapSecondTable -> Day -> DiffTime
 utcDayLength table day = realToFrac (86400 + (table (addDays 1 day)) - (table day))
 
 dayStart :: LeapSecondTable -> Day -> AbsoluteTime
-dayStart table day = MkAbsoluteTime	(realToFrac ((toModifiedJulianDay day) * 86400 + (table day)))
+dayStart table day = MkAbsoluteTime    (realToFrac ((toModifiedJulianDay day) * 86400 + (table day)))
 
 utcToTAITime :: LeapSecondTable -> UTCTime -> AbsoluteTime
 utcToTAITime table (UTCTime day dtime) = MkAbsoluteTime (t + dtime) where
-	MkAbsoluteTime t = dayStart table day
+    MkAbsoluteTime t = dayStart table day
 
 taiToUTCTime :: LeapSecondTable -> AbsoluteTime -> UTCTime
 taiToUTCTime table abstime = stable (ModifiedJulianDay (div' (unAbsoluteTime abstime) 86400)) where
-	stable day = if (day == day') then UTCTime day dtime else stable day' where
-		dayt = dayStart table day
-		dtime = diffAbsoluteTime abstime dayt
-		day' = addDays (div' dtime (utcDayLength table day)) day
+    stable day = if (day == day') then UTCTime day dtime else stable day' where
+        dayt = dayStart table day
+        dtime = diffAbsoluteTime abstime dayt
+        day' = addDays (div' dtime (utcDayLength table day)) day
 
 -- | Parse the contents of a tai-utc.dat file.
 -- This does not do any kind of validation and will return a bad table for input
 -- not in the correct format.
 parseTAIUTCDATFile :: String -> LeapSecondTable
 parseTAIUTCDATFile ss = offsetlist 0 (parse (lines ss)) where
-	offsetlist :: Integer -> [(Day,Integer)] -> LeapSecondTable
-	offsetlist i [] _ = i
-	offsetlist i ((d0,_):_) d | d < d0 = i
-	offsetlist _ ((_,i0):xx) d = offsetlist i0 xx d
-	
-	parse :: [String] -> [(Day,Integer)]
-	parse [] = []
-	parse (a:as) = let
-		ps = parse as
-	 in case matchLine a of
-		Just di -> di:ps
-		Nothing -> ps
-	
-	matchLine :: String -> Maybe (Day,Integer)
-	matchLine s = do
-		check0S s
-		(d,s') <- findJD s
-		i <- findOffset s'
-		return (d,i)
-	
-	-- a bit fragile
-	check0S :: String -> Maybe ()
-	check0S "X 0.0      S" = Just ()
-	check0S [] = Nothing
-	check0S (_:cs) = check0S cs
-	
-	findJD :: String -> Maybe (Day,String)
-	findJD ('=':'J':'D':s) = do
-		d <- getInteger '5' s
-		return (ModifiedJulianDay (d - 2400000),s)
-	findJD [] = Nothing
-	findJD (_:cs) = findJD cs
-	
-	findOffset :: String -> Maybe Integer
-	findOffset ('T':'A':'I':'-':'U':'T':'C':'=':s) = getInteger '0' s
-	findOffset [] = Nothing
-	findOffset (_:cs) = findOffset cs
-	
-	getInteger :: Char -> String -> Maybe Integer
-	getInteger p s = do
-		digits <- getDigits p s
-		fromDigits 0 digits
-	
-	getDigits :: Char -> String -> Maybe String
-	getDigits p (' ':s) = getDigits p s
-	getDigits p (c:cs) | c >= '0' && c <= '9' = do
-		s <- getDigits p cs
-		return (c:s)
-	getDigits p ('.':p1:_) = if p == p1 then Just [] else Nothing
-	getDigits _ _ = Nothing
-		
-	
-	fromDigits :: Integer -> String -> Maybe Integer
-	fromDigits i [] = Just i
-	fromDigits i (c:cs) | c >= '0' && c <= '9' = fromDigits ((i * 10) + (fromIntegral ((fromEnum c) - (fromEnum '0')))) cs
-	fromDigits _ _ = Nothing
+    offsetlist :: Integer -> [(Day,Integer)] -> LeapSecondTable
+    offsetlist i [] _ = i
+    offsetlist i ((d0,_):_) d | d < d0 = i
+    offsetlist _ ((_,i0):xx) d = offsetlist i0 xx d
+
+    parse :: [String] -> [(Day,Integer)]
+    parse [] = []
+    parse (a:as) = let
+        ps = parse as
+     in case matchLine a of
+        Just di -> di:ps
+        Nothing -> ps
+
+    matchLine :: String -> Maybe (Day,Integer)
+    matchLine s = do
+        check0S s
+        (d,s') <- findJD s
+        i <- findOffset s'
+        return (d,i)
+
+    -- a bit fragile
+    check0S :: String -> Maybe ()
+    check0S "X 0.0      S" = Just ()
+    check0S [] = Nothing
+    check0S (_:cs) = check0S cs
+
+    findJD :: String -> Maybe (Day,String)
+    findJD ('=':'J':'D':s) = do
+        d <- getInteger '5' s
+        return (ModifiedJulianDay (d - 2400000),s)
+    findJD [] = Nothing
+    findJD (_:cs) = findJD cs
+
+    findOffset :: String -> Maybe Integer
+    findOffset ('T':'A':'I':'-':'U':'T':'C':'=':s) = getInteger '0' s
+    findOffset [] = Nothing
+    findOffset (_:cs) = findOffset cs
+
+    getInteger :: Char -> String -> Maybe Integer
+    getInteger p s = do
+        digits <- getDigits p s
+        fromDigits 0 digits
+
+    getDigits :: Char -> String -> Maybe String
+    getDigits p (' ':s) = getDigits p s
+    getDigits p (c:cs) | c >= '0' && c <= '9' = do
+        s <- getDigits p cs
+        return (c:s)
+    getDigits p ('.':p1:_) = if p == p1 then Just [] else Nothing
+    getDigits _ _ = Nothing
+
+
+    fromDigits :: Integer -> String -> Maybe Integer
+    fromDigits i [] = Just i
+    fromDigits i (c:cs) | c >= '0' && c <= '9' = fromDigits ((i * 10) + (fromIntegral ((fromEnum c) - (fromEnum '0')))) cs
+    fromDigits _ _ = Nothing
 
 -- typical line format:
 -- 1972 JAN  1 =JD 2441317.5  TAI-UTC=  10.0       S + (MJD - 41317.) X 0.0      S

--- a/lib/Data/Time/Clock/UTC.hs
+++ b/lib/Data/Time/Clock/UTC.hs
@@ -4,16 +4,16 @@
 -- #hide
 module Data.Time.Clock.UTC
 (
-	-- * UTC
-	-- | UTC is time as measured by a clock, corrected to keep pace with the earth by adding or removing
-	-- occasional seconds, known as \"leap seconds\".
-	-- These corrections are not predictable and are announced with six month's notice.
-	-- No table of these corrections is provided, as any program compiled with it would become
-	-- out of date in six months.
-	-- 
-	-- If you don't care about leap seconds, use UTCTime and NominalDiffTime for your clock calculations,
-	-- and you'll be fine.
-	UTCTime(..),NominalDiffTime
+    -- * UTC
+    -- | UTC is time as measured by a clock, corrected to keep pace with the earth by adding or removing
+    -- occasional seconds, known as \"leap seconds\".
+    -- These corrections are not predictable and are announced with six month's notice.
+    -- No table of these corrections is provided, as any program compiled with it would become
+    -- out of date in six months.
+    --
+    -- If you don't care about leap seconds, use UTCTime and NominalDiffTime for your clock calculations,
+    -- and you'll be fine.
+    UTCTime(..),NominalDiffTime
 ) where
 
 import Control.DeepSeq
@@ -29,10 +29,10 @@ import Data.Data
 -- It consists of the day number, and a time offset from midnight.
 -- Note that if a day has a leap second added to it, it will have 86401 seconds.
 data UTCTime = UTCTime {
-	-- | the day
-	utctDay :: Day,
-	-- | the time from midnight, 0 <= t < 86401s (because of leap-seconds)
-	utctDayTime :: DiffTime
+    -- | the day
+    utctDay :: Day,
+    -- | the time from midnight, 0 <= t < 86401s (because of leap-seconds)
+    utctDayTime :: DiffTime
 }
 #if LANGUAGE_DeriveDataTypeable
 #if LANGUAGE_Rank2Types
@@ -43,15 +43,15 @@ data UTCTime = UTCTime {
 #endif
 
 instance NFData UTCTime where
-	rnf (UTCTime d t) = d `deepseq` t `deepseq` ()
+    rnf (UTCTime d t) = d `deepseq` t `deepseq` ()
 
 instance Eq UTCTime where
-	(UTCTime da ta) == (UTCTime db tb) = (da == db) && (ta == tb)
+    (UTCTime da ta) == (UTCTime db tb) = (da == db) && (ta == tb)
 
 instance Ord UTCTime where
-	compare (UTCTime da ta) (UTCTime db tb) = case (compare da db) of
-		EQ -> compare ta tb
-		cmp -> cmp
+    compare (UTCTime da ta) (UTCTime db tb) = case (compare da db) of
+        EQ -> compare ta tb
+        cmp -> cmp
 
 -- | This is a length of time, as measured by UTC.
 -- Conversion functions will treat it as seconds.
@@ -74,46 +74,46 @@ instance NFData NominalDiffTime where -- FIXME: Data.Fixed had no NFData instanc
         rnf ndt = seq ndt ()
 
 instance Enum NominalDiffTime where
-	succ (MkNominalDiffTime a) = MkNominalDiffTime (succ a)
-	pred (MkNominalDiffTime a) = MkNominalDiffTime (pred a)
-	toEnum = MkNominalDiffTime . toEnum
-	fromEnum (MkNominalDiffTime a) = fromEnum a
-	enumFrom (MkNominalDiffTime a) = fmap MkNominalDiffTime (enumFrom a)
-	enumFromThen (MkNominalDiffTime a) (MkNominalDiffTime b) = fmap MkNominalDiffTime (enumFromThen a b)
-	enumFromTo (MkNominalDiffTime a) (MkNominalDiffTime b) = fmap MkNominalDiffTime (enumFromTo a b)
-	enumFromThenTo (MkNominalDiffTime a) (MkNominalDiffTime b) (MkNominalDiffTime c) = fmap MkNominalDiffTime (enumFromThenTo a b c)
+    succ (MkNominalDiffTime a) = MkNominalDiffTime (succ a)
+    pred (MkNominalDiffTime a) = MkNominalDiffTime (pred a)
+    toEnum = MkNominalDiffTime . toEnum
+    fromEnum (MkNominalDiffTime a) = fromEnum a
+    enumFrom (MkNominalDiffTime a) = fmap MkNominalDiffTime (enumFrom a)
+    enumFromThen (MkNominalDiffTime a) (MkNominalDiffTime b) = fmap MkNominalDiffTime (enumFromThen a b)
+    enumFromTo (MkNominalDiffTime a) (MkNominalDiffTime b) = fmap MkNominalDiffTime (enumFromTo a b)
+    enumFromThenTo (MkNominalDiffTime a) (MkNominalDiffTime b) (MkNominalDiffTime c) = fmap MkNominalDiffTime (enumFromThenTo a b c)
 
 instance Show NominalDiffTime where
-	show (MkNominalDiffTime t) = (showFixed True t) ++ "s"
+    show (MkNominalDiffTime t) = (showFixed True t) ++ "s"
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Num NominalDiffTime where
-	(MkNominalDiffTime a) + (MkNominalDiffTime b) = MkNominalDiffTime (a + b)
-	(MkNominalDiffTime a) - (MkNominalDiffTime b) = MkNominalDiffTime (a - b)
-	(MkNominalDiffTime a) * (MkNominalDiffTime b) = MkNominalDiffTime (a * b)
-	negate (MkNominalDiffTime a) = MkNominalDiffTime (negate a)
-	abs (MkNominalDiffTime a) = MkNominalDiffTime (abs a)
-	signum (MkNominalDiffTime a) = MkNominalDiffTime (signum a)
-	fromInteger i = MkNominalDiffTime (fromInteger i)
+    (MkNominalDiffTime a) + (MkNominalDiffTime b) = MkNominalDiffTime (a + b)
+    (MkNominalDiffTime a) - (MkNominalDiffTime b) = MkNominalDiffTime (a - b)
+    (MkNominalDiffTime a) * (MkNominalDiffTime b) = MkNominalDiffTime (a * b)
+    negate (MkNominalDiffTime a) = MkNominalDiffTime (negate a)
+    abs (MkNominalDiffTime a) = MkNominalDiffTime (abs a)
+    signum (MkNominalDiffTime a) = MkNominalDiffTime (signum a)
+    fromInteger i = MkNominalDiffTime (fromInteger i)
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Real NominalDiffTime where
-	toRational (MkNominalDiffTime a) = toRational a
+    toRational (MkNominalDiffTime a) = toRational a
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance Fractional NominalDiffTime where
-	(MkNominalDiffTime a) / (MkNominalDiffTime b) = MkNominalDiffTime (a / b)
-	recip (MkNominalDiffTime a) = MkNominalDiffTime (recip a)
-	fromRational r = MkNominalDiffTime (fromRational r)
+    (MkNominalDiffTime a) / (MkNominalDiffTime b) = MkNominalDiffTime (a / b)
+    recip (MkNominalDiffTime a) = MkNominalDiffTime (recip a)
+    fromRational r = MkNominalDiffTime (fromRational r)
 
 -- necessary because H98 doesn't have "cunning newtype" derivation
 instance RealFrac NominalDiffTime where
-	properFraction (MkNominalDiffTime a) = (i,MkNominalDiffTime f) where
-		(i,f) = properFraction a
-	truncate (MkNominalDiffTime a) = truncate a
-	round (MkNominalDiffTime a) = round a
-	ceiling (MkNominalDiffTime a) = ceiling a
-	floor (MkNominalDiffTime a) = floor a
+    properFraction (MkNominalDiffTime a) = (i,MkNominalDiffTime f) where
+        (i,f) = properFraction a
+    truncate (MkNominalDiffTime a) = truncate a
+    round (MkNominalDiffTime a) = round a
+    ceiling (MkNominalDiffTime a) = ceiling a
+    floor (MkNominalDiffTime a) = floor a
 
 {-# RULES
 "realToFrac/DiffTime->NominalDiffTime"   realToFrac = \ dt -> MkNominalDiffTime (realToFrac dt)

--- a/lib/Data/Time/Format.hs
+++ b/lib/Data/Time/Format.hs
@@ -1,9 +1,9 @@
 module Data.Time.Format
-	(
-	-- * UNIX-style formatting
-	NumericPadOption,FormatTime(..),formatTime,
-	module Data.Time.Format.Parse
-	) where
+    (
+    -- * UNIX-style formatting
+    NumericPadOption,FormatTime(..),formatTime,
+    module Data.Time.Format.Parse
+    ) where
 
 import Data.Time.Format.Parse
 import Data.Time.LocalTime
@@ -20,15 +20,15 @@ import Data.Fixed
 
 -- <http://www.opengroup.org/onlinepubs/007908799/xsh/strftime.html>
 class FormatTime t where
-	formatCharacter :: Char -> Maybe (TimeLocale -> Maybe NumericPadOption -> t -> String)
+    formatCharacter :: Char -> Maybe (TimeLocale -> Maybe NumericPadOption -> t -> String)
 
 formatChar :: (FormatTime t) => Char -> TimeLocale -> Maybe NumericPadOption -> t -> String
 formatChar '%' _ _ _ = "%"
 formatChar 't' _ _ _ = "\t"
 formatChar 'n' _ _ _ = "\n"
 formatChar c locale mpado t = case (formatCharacter c) of
-	Just f -> f locale mpado t
-	_ -> ""
+    Just f -> f locale mpado t
+    _ -> ""
 
 -- | Substitute various time-related information for each %-code in the string, as per 'formatCharacter'.
 --
@@ -96,7 +96,7 @@ formatChar c locale mpado t = case (formatCharacter c) of
 -- For 'UTCTime' and 'ZonedTime':
 --
 -- [@%s@] number of whole seconds since the Unix epoch. For times before
--- the Unix epoch, this is a negative number. Note that in @%s.%q@ and @%s%Q@ 
+-- the Unix epoch, this is a negative number. Note that in @%s.%q@ and @%s%Q@
 -- the decimals are positive, not negative. For example, 0.9 seconds
 -- before the Unix epoch is formatted as @-1.1@ with @%s%Q@.
 --
@@ -156,91 +156,91 @@ formatTime locale ('%':c:cs) t = (formatChar c locale Nothing t) ++ (formatTime 
 formatTime locale (c:cs) t = c:(formatTime locale cs t)
 
 instance FormatTime LocalTime where
-	formatCharacter 'c' = Just (\locale _ -> formatTime locale (dateTimeFmt locale))
-	formatCharacter c = case (formatCharacter c) of
-		Just f -> Just (\locale mpado dt -> f locale mpado (localDay dt))
-		Nothing -> case (formatCharacter c) of
-			Just f -> Just (\locale mpado dt -> f locale mpado (localTimeOfDay dt))
-			Nothing -> Nothing
+    formatCharacter 'c' = Just (\locale _ -> formatTime locale (dateTimeFmt locale))
+    formatCharacter c = case (formatCharacter c) of
+        Just f -> Just (\locale mpado dt -> f locale mpado (localDay dt))
+        Nothing -> case (formatCharacter c) of
+            Just f -> Just (\locale mpado dt -> f locale mpado (localTimeOfDay dt))
+            Nothing -> Nothing
 
 instance FormatTime TimeOfDay where
-	-- Aggregate
-	formatCharacter 'R' = Just (\locale _ -> formatTime locale "%H:%M")
-	formatCharacter 'T' = Just (\locale _ -> formatTime locale "%H:%M:%S")
-	formatCharacter 'X' = Just (\locale _ -> formatTime locale (timeFmt locale))
-	formatCharacter 'r' = Just (\locale _ -> formatTime locale (time12Fmt locale))
-	-- AM/PM
-	formatCharacter 'P' = Just (\locale _ day -> map toLower ((if (todHour day) < 12 then fst else snd) (amPm locale)))
-	formatCharacter 'p' = Just (\locale _ day -> (if (todHour day) < 12 then fst else snd) (amPm locale))
-	-- Hour
-	formatCharacter 'H' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . todHour)
-	formatCharacter 'I' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . (\h -> (mod (h - 1) 12) + 1) . todHour)
-	formatCharacter 'k' = Just (\_ opt -> (show2 (fromMaybe (Just ' ') opt)) . todHour)
-	formatCharacter 'l' = Just (\_ opt -> (show2 (fromMaybe (Just ' ') opt)) . (\h -> (mod (h - 1) 12) + 1) . todHour)
-	-- Minute
-	formatCharacter 'M' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . todMin)
-	-- Second
-	formatCharacter 'S' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt) :: Int -> String) . truncate . todSec)
-	formatCharacter 'q' = Just (\_ _ -> drop 1 . dropWhile (/='.') . showFixed False . todSec)
-	formatCharacter 'Q' = Just (\_ _ -> dropWhile (/='.') . showFixed True . todSec)
+    -- Aggregate
+    formatCharacter 'R' = Just (\locale _ -> formatTime locale "%H:%M")
+    formatCharacter 'T' = Just (\locale _ -> formatTime locale "%H:%M:%S")
+    formatCharacter 'X' = Just (\locale _ -> formatTime locale (timeFmt locale))
+    formatCharacter 'r' = Just (\locale _ -> formatTime locale (time12Fmt locale))
+    -- AM/PM
+    formatCharacter 'P' = Just (\locale _ day -> map toLower ((if (todHour day) < 12 then fst else snd) (amPm locale)))
+    formatCharacter 'p' = Just (\locale _ day -> (if (todHour day) < 12 then fst else snd) (amPm locale))
+    -- Hour
+    formatCharacter 'H' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . todHour)
+    formatCharacter 'I' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . (\h -> (mod (h - 1) 12) + 1) . todHour)
+    formatCharacter 'k' = Just (\_ opt -> (show2 (fromMaybe (Just ' ') opt)) . todHour)
+    formatCharacter 'l' = Just (\_ opt -> (show2 (fromMaybe (Just ' ') opt)) . (\h -> (mod (h - 1) 12) + 1) . todHour)
+    -- Minute
+    formatCharacter 'M' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . todMin)
+    -- Second
+    formatCharacter 'S' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt) :: Int -> String) . truncate . todSec)
+    formatCharacter 'q' = Just (\_ _ -> drop 1 . dropWhile (/='.') . showFixed False . todSec)
+    formatCharacter 'Q' = Just (\_ _ -> dropWhile (/='.') . showFixed True . todSec)
 
-	-- Default
-	formatCharacter _   = Nothing
+    -- Default
+    formatCharacter _   = Nothing
 
 instance FormatTime ZonedTime where
-	formatCharacter 'c' = Just (\locale _ -> formatTime locale (dateTimeFmt locale))
-	formatCharacter 's' = Just (\_ _ zt -> show (floor (utcTimeToPOSIXSeconds (zonedTimeToUTC zt)) :: Integer))
-	formatCharacter c = case (formatCharacter c) of
-		Just f -> Just (\locale mpado dt -> f locale mpado (zonedTimeToLocalTime dt))
-		Nothing -> case (formatCharacter c) of
-			Just f -> Just (\locale mpado dt -> f locale mpado (zonedTimeZone dt))
-			Nothing -> Nothing
+    formatCharacter 'c' = Just (\locale _ -> formatTime locale (dateTimeFmt locale))
+    formatCharacter 's' = Just (\_ _ zt -> show (floor (utcTimeToPOSIXSeconds (zonedTimeToUTC zt)) :: Integer))
+    formatCharacter c = case (formatCharacter c) of
+        Just f -> Just (\locale mpado dt -> f locale mpado (zonedTimeToLocalTime dt))
+        Nothing -> case (formatCharacter c) of
+            Just f -> Just (\locale mpado dt -> f locale mpado (zonedTimeZone dt))
+            Nothing -> Nothing
 
 instance FormatTime TimeZone where
-	formatCharacter 'z' = Just (\_ opt -> timeZoneOffsetString' (fromMaybe (Just '0') opt))
-	formatCharacter 'Z' = 
+    formatCharacter 'z' = Just (\_ opt -> timeZoneOffsetString' (fromMaybe (Just '0') opt))
+    formatCharacter 'Z' =
             Just (\_ opt z -> let n = timeZoneName z
                            in if null n then timeZoneOffsetString' (fromMaybe (Just '0') opt) z else n)
-	formatCharacter _ = Nothing
+    formatCharacter _ = Nothing
 
 instance FormatTime Day where
-	-- Aggregate
-	formatCharacter 'D' = Just (\locale _ -> formatTime locale "%m/%d/%y")
-	formatCharacter 'F' = Just (\locale _ -> formatTime locale "%Y-%m-%d")
-	formatCharacter 'x' = Just (\locale _ -> formatTime locale (dateFmt locale))
+    -- Aggregate
+    formatCharacter 'D' = Just (\locale _ -> formatTime locale "%m/%d/%y")
+    formatCharacter 'F' = Just (\locale _ -> formatTime locale "%Y-%m-%d")
+    formatCharacter 'x' = Just (\locale _ -> formatTime locale (dateFmt locale))
 
-	-- Year Count
-	formatCharacter 'Y' = Just (\_ opt -> (show4 (fromMaybe Nothing opt)) . fst . toOrdinalDate)
-	formatCharacter 'y' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . mod100 . fst . toOrdinalDate)
-	formatCharacter 'C' = Just (\_ opt -> (show2 (fromMaybe Nothing opt)) . div100 . fst . toOrdinalDate)
-	-- Month of Year
-	formatCharacter 'B' = Just (\locale _ -> fst . (\(_,m,_) -> (months locale) !! (m - 1)) . toGregorian)
-	formatCharacter 'b' = Just (\locale _ -> snd . (\(_,m,_) -> (months locale) !! (m - 1)) . toGregorian)
-	formatCharacter 'h' = Just (\locale _ -> snd . (\(_,m,_) -> (months locale) !! (m - 1)) . toGregorian)
-	formatCharacter 'm' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . (\(_,m,_) -> m) . toGregorian)
-	-- Day of Month
-	formatCharacter 'd' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . (\(_,_,d) -> d) . toGregorian)
-	formatCharacter 'e' = Just (\_ opt -> (show2 (fromMaybe (Just ' ') opt)) . (\(_,_,d) -> d) . toGregorian)
-	-- Day of Year
-	formatCharacter 'j' = Just (\_ opt -> (show3 (fromMaybe (Just '0') opt)) . snd . toOrdinalDate)
+    -- Year Count
+    formatCharacter 'Y' = Just (\_ opt -> (show4 (fromMaybe Nothing opt)) . fst . toOrdinalDate)
+    formatCharacter 'y' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . mod100 . fst . toOrdinalDate)
+    formatCharacter 'C' = Just (\_ opt -> (show2 (fromMaybe Nothing opt)) . div100 . fst . toOrdinalDate)
+    -- Month of Year
+    formatCharacter 'B' = Just (\locale _ -> fst . (\(_,m,_) -> (months locale) !! (m - 1)) . toGregorian)
+    formatCharacter 'b' = Just (\locale _ -> snd . (\(_,m,_) -> (months locale) !! (m - 1)) . toGregorian)
+    formatCharacter 'h' = Just (\locale _ -> snd . (\(_,m,_) -> (months locale) !! (m - 1)) . toGregorian)
+    formatCharacter 'm' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . (\(_,m,_) -> m) . toGregorian)
+    -- Day of Month
+    formatCharacter 'd' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . (\(_,_,d) -> d) . toGregorian)
+    formatCharacter 'e' = Just (\_ opt -> (show2 (fromMaybe (Just ' ') opt)) . (\(_,_,d) -> d) . toGregorian)
+    -- Day of Year
+    formatCharacter 'j' = Just (\_ opt -> (show3 (fromMaybe (Just '0') opt)) . snd . toOrdinalDate)
 
-	-- ISO 8601 Week Date
-	formatCharacter 'G' = Just (\_ opt -> (show4 (fromMaybe Nothing opt)) . (\(y,_,_) -> y) . toWeekDate)
-	formatCharacter 'g' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . mod100 . (\(y,_,_) -> y) . toWeekDate)
-	formatCharacter 'f' = Just (\_ opt -> (show2 (fromMaybe Nothing opt)) . div100 . (\(y,_,_) -> y) . toWeekDate)
+    -- ISO 8601 Week Date
+    formatCharacter 'G' = Just (\_ opt -> (show4 (fromMaybe Nothing opt)) . (\(y,_,_) -> y) . toWeekDate)
+    formatCharacter 'g' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . mod100 . (\(y,_,_) -> y) . toWeekDate)
+    formatCharacter 'f' = Just (\_ opt -> (show2 (fromMaybe Nothing opt)) . div100 . (\(y,_,_) -> y) . toWeekDate)
 
-	formatCharacter 'V' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . (\(_,w,_) -> w) . toWeekDate)
-	formatCharacter 'u' = Just (\_ _ -> show . (\(_,_,d) -> d) . toWeekDate)
+    formatCharacter 'V' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . (\(_,w,_) -> w) . toWeekDate)
+    formatCharacter 'u' = Just (\_ _ -> show . (\(_,_,d) -> d) . toWeekDate)
 
-	-- Day of week
-	formatCharacter 'a' = Just (\locale _ -> snd . ((wDays locale) !!) . snd . sundayStartWeek)
-	formatCharacter 'A' = Just (\locale _ -> fst . ((wDays locale) !!) . snd . sundayStartWeek)
-	formatCharacter 'U' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . fst . sundayStartWeek)
-	formatCharacter 'w' = Just (\_ _ -> show . snd . sundayStartWeek)
-	formatCharacter 'W' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . fst . mondayStartWeek)
-	
-	-- Default
-	formatCharacter _   = Nothing
+    -- Day of week
+    formatCharacter 'a' = Just (\locale _ -> snd . ((wDays locale) !!) . snd . sundayStartWeek)
+    formatCharacter 'A' = Just (\locale _ -> fst . ((wDays locale) !!) . snd . sundayStartWeek)
+    formatCharacter 'U' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . fst . sundayStartWeek)
+    formatCharacter 'w' = Just (\_ _ -> show . snd . sundayStartWeek)
+    formatCharacter 'W' = Just (\_ opt -> (show2 (fromMaybe (Just '0') opt)) . fst . mondayStartWeek)
+
+    -- Default
+    formatCharacter _   = Nothing
 
 instance FormatTime UTCTime where
-	formatCharacter c = fmap (\f locale mpado t -> f locale mpado (utcToZonedTime utc t)) (formatCharacter c)
+    formatCharacter c = fmap (\f locale mpado t -> f locale mpado (utcToZonedTime utc t)) (formatCharacter c)

--- a/lib/Data/Time/LocalTime.hs
+++ b/lib/Data/Time/LocalTime.hs
@@ -1,8 +1,8 @@
 module Data.Time.LocalTime
 (
-	module Data.Time.LocalTime.TimeZone,
-	module Data.Time.LocalTime.TimeOfDay,
-	module Data.Time.LocalTime.LocalTime
+    module Data.Time.LocalTime.TimeZone,
+    module Data.Time.LocalTime.TimeOfDay,
+    module Data.Time.LocalTime.LocalTime
 ) where
 
 import Data.Time.LocalTime.TimeZone

--- a/lib/Data/Time/LocalTime/LocalTime.hs
+++ b/lib/Data/Time/LocalTime/LocalTime.hs
@@ -4,13 +4,13 @@
 -- #hide
 module Data.Time.LocalTime.LocalTime
 (
-	-- * Local Time
-	LocalTime(..),
+    -- * Local Time
+    LocalTime(..),
 
-	-- converting UTC and UT1 times to LocalTime
-	utcToLocalTime,localTimeToUTC,ut1ToLocalTime,localTimeToUT1,
-	
-	ZonedTime(..),utcToZonedTime,zonedTimeToUTC,getZonedTime,utcToLocalZonedTime
+    -- converting UTC and UT1 times to LocalTime
+    utcToLocalTime,localTimeToUTC,ut1ToLocalTime,localTimeToUT1,
+
+    ZonedTime(..),utcToZonedTime,zonedTimeToUTC,getZonedTime,utcToLocalZonedTime
 ) where
 
 import Data.Time.LocalTime.TimeOfDay
@@ -28,8 +28,8 @@ import Data.Data
 -- Conversion of this (as local civil time) to UTC depends on the time zone.
 -- Conversion of this (as local mean time) to UT1 depends on the longitude.
 data LocalTime = LocalTime {
-	localDay    :: Day,
-	localTimeOfDay   :: TimeOfDay
+    localDay    :: Day,
+    localTimeOfDay   :: TimeOfDay
 } deriving (Eq,Ord
 #if LANGUAGE_DeriveDataTypeable
 #if LANGUAGE_Rank2Types
@@ -41,27 +41,27 @@ data LocalTime = LocalTime {
     )
 
 instance NFData LocalTime where
-	rnf (LocalTime d t) = d `deepseq` t `deepseq` ()
+    rnf (LocalTime d t) = d `deepseq` t `deepseq` ()
 
 instance Show LocalTime where
-	show (LocalTime d t) = (showGregorian d) ++ " " ++ (show t)
+    show (LocalTime d t) = (showGregorian d) ++ " " ++ (show t)
 
 -- | show a UTC time in a given time zone as a LocalTime
 utcToLocalTime :: TimeZone -> UTCTime -> LocalTime
 utcToLocalTime tz (UTCTime day dt) = LocalTime (addDays i day) tod where
-	(i,tod) = utcToLocalTimeOfDay tz (timeToTimeOfDay dt)
+    (i,tod) = utcToLocalTimeOfDay tz (timeToTimeOfDay dt)
 
 -- | find out what UTC time a given LocalTime in a given time zone is
 localTimeToUTC :: TimeZone -> LocalTime -> UTCTime
 localTimeToUTC tz (LocalTime day tod) = UTCTime (addDays i day) (timeOfDayToTime todUTC) where
-	(i,todUTC) = localToUTCTimeOfDay tz tod
+    (i,todUTC) = localToUTCTimeOfDay tz tod
 
 -- | 1st arg is observation meridian in degrees, positive is East
 ut1ToLocalTime :: Rational -> UniversalTime -> LocalTime
 ut1ToLocalTime long (ModJulianDate date) = LocalTime (ModifiedJulianDay localMJD) (dayFractionToTimeOfDay localToDOffset) where
-	localTime = date + long / 360 :: Rational
-	localMJD = floor localTime
-	localToDOffset = localTime - (fromIntegral localMJD)	
+    localTime = date + long / 360 :: Rational
+    localMJD = floor localTime
+    localToDOffset = localTime - (fromIntegral localMJD)
 
 -- | 1st arg is observation meridian in degrees, positive is East
 localTimeToUT1 :: Rational -> LocalTime -> UniversalTime
@@ -69,8 +69,8 @@ localTimeToUT1 long (LocalTime (ModifiedJulianDay localMJD) tod) = ModJulianDate
 
 -- | A local time together with a TimeZone.
 data ZonedTime = ZonedTime {
-	zonedTimeToLocalTime :: LocalTime,
-	zonedTimeZone :: TimeZone
+    zonedTimeToLocalTime :: LocalTime,
+    zonedTimeZone :: TimeZone
 }
 #if LANGUAGE_DeriveDataTypeable
 #if LANGUAGE_Rank2Types
@@ -81,7 +81,7 @@ data ZonedTime = ZonedTime {
 #endif
 
 instance NFData ZonedTime where
-	rnf (ZonedTime lt z) = lt `deepseq` z `deepseq` ()
+    rnf (ZonedTime lt z) = lt `deepseq` z `deepseq` ()
 
 utcToZonedTime :: TimeZone -> UTCTime -> ZonedTime
 utcToZonedTime zone time = ZonedTime (utcToLocalTime zone time) zone
@@ -90,20 +90,20 @@ zonedTimeToUTC :: ZonedTime -> UTCTime
 zonedTimeToUTC (ZonedTime t zone) = localTimeToUTC zone t
 
 instance Show ZonedTime where
-	show (ZonedTime t zone) = show t ++ " " ++ show zone
+    show (ZonedTime t zone) = show t ++ " " ++ show zone
 
 -- orphan instance
 instance Show UTCTime where
-	show t = show (utcToZonedTime utc t)
+    show t = show (utcToZonedTime utc t)
 
 getZonedTime :: IO ZonedTime
 getZonedTime = do
-	t <- getCurrentTime
-	zone <- getTimeZone t
-	return (utcToZonedTime zone t)
+    t <- getCurrentTime
+    zone <- getTimeZone t
+    return (utcToZonedTime zone t)
 
 -- |
 utcToLocalZonedTime :: UTCTime -> IO ZonedTime
 utcToLocalZonedTime t = do
-	zone <- getTimeZone t
-	return (utcToZonedTime zone t)
+    zone <- getTimeZone t
+    return (utcToZonedTime zone t)

--- a/lib/Data/Time/LocalTime/TimeOfDay.hs
+++ b/lib/Data/Time/LocalTime/TimeOfDay.hs
@@ -3,11 +3,11 @@
 -- #hide
 module Data.Time.LocalTime.TimeOfDay
 (
-	-- * Time of day
-	TimeOfDay(..),midnight,midday,makeTimeOfDayValid,
-	utcToLocalTimeOfDay,localToUTCTimeOfDay,
-	timeToTimeOfDay,timeOfDayToTime,
-	dayFractionToTimeOfDay,timeOfDayToDayFraction
+    -- * Time of day
+    TimeOfDay(..),midnight,midday,makeTimeOfDayValid,
+    utcToLocalTimeOfDay,localToUTCTimeOfDay,
+    timeToTimeOfDay,timeOfDayToTime,
+    dayFractionToTimeOfDay,timeOfDayToDayFraction
 ) where
 
 import Data.Time.LocalTime.TimeZone
@@ -22,13 +22,13 @@ import Data.Data
 
 -- | Time of day as represented in hour, minute and second (with picoseconds), typically used to express local time of day.
 data TimeOfDay = TimeOfDay {
-	-- | range 0 - 23
-	todHour    :: Int,
-	-- | range 0 - 59
-	todMin     :: Int,
-	-- | Note that 0 <= todSec < 61, accomodating leap seconds.
-	-- Any local minute may have a leap second, since leap seconds happen in all zones simultaneously
-	todSec     :: Pico
+    -- | range 0 - 23
+    todHour    :: Int,
+    -- | range 0 - 59
+    todMin     :: Int,
+    -- | Note that 0 <= todSec < 61, accomodating leap seconds.
+    -- Any local minute may have a leap second, since leap seconds happen in all zones simultaneously
+    todSec     :: Pico
 } deriving (Eq,Ord
 #if LANGUAGE_DeriveDataTypeable
 #if LANGUAGE_Rank2Types
@@ -40,7 +40,7 @@ data TimeOfDay = TimeOfDay {
     )
 
 instance NFData TimeOfDay where
-	rnf (TimeOfDay h m s) = h `deepseq` m `deepseq` s `seq` () -- FIXME: Data.Fixed had no NFData instances yet at time of writing
+    rnf (TimeOfDay h m s) = h `deepseq` m `deepseq` s `seq` () -- FIXME: Data.Fixed had no NFData instances yet at time of writing
 
 -- | Hour zero
 midnight :: TimeOfDay
@@ -51,20 +51,20 @@ midday :: TimeOfDay
 midday = TimeOfDay 12 0 0
 
 instance Show TimeOfDay where
-	show (TimeOfDay h m s) = (show2 (Just '0') h) ++ ":" ++ (show2 (Just '0') m) ++ ":" ++ (show2Fixed (Just '0') s)
+    show (TimeOfDay h m s) = (show2 (Just '0') h) ++ ":" ++ (show2 (Just '0') m) ++ ":" ++ (show2Fixed (Just '0') s)
 
 makeTimeOfDayValid :: Int -> Int -> Pico -> Maybe TimeOfDay
 makeTimeOfDayValid h m s = do
-	_ <- clipValid 0 23 h
-	_ <- clipValid 0 59 m
-	_ <- clipValid 0 60.999999999999 s
-	return (TimeOfDay h m s)
+    _ <- clipValid 0 23 h
+    _ <- clipValid 0 59 m
+    _ <- clipValid 0 60.999999999999 s
+    return (TimeOfDay h m s)
 
 -- | Convert a ToD in UTC to a ToD in some timezone, together with a day adjustment.
 utcToLocalTimeOfDay :: TimeZone -> TimeOfDay -> (Integer,TimeOfDay)
 utcToLocalTimeOfDay zone (TimeOfDay h m s) = (fromIntegral (div h' 24),TimeOfDay (mod h' 24) (mod m' 60) s) where
-	m' = m + timeZoneMinutes zone
-	h' = h + (div m' 60)
+    m' = m + timeZoneMinutes zone
+    h' = h + (div m' 60)
 
 -- | Convert a ToD in some timezone to a ToD in UTC, together with a day adjustment.
 localToUTCTimeOfDay :: TimeZone -> TimeOfDay -> (Integer,TimeOfDay)
@@ -78,11 +78,11 @@ posixDayLength = fromInteger 86400
 timeToTimeOfDay :: DiffTime -> TimeOfDay
 timeToTimeOfDay dt | dt >= posixDayLength = TimeOfDay 23 59 (60 + (realToFrac (dt - posixDayLength)))
 timeToTimeOfDay dt = TimeOfDay (fromInteger h) (fromInteger m) s where
-	s' = realToFrac dt
-	s = mod' s' 60
-	m' = div' s' 60
-	m = mod' m' 60
-	h = div' m' 60
+    s' = realToFrac dt
+    s = mod' s' 60
+    m' = div' s' 60
+    m = mod' m' 60
+    h = div' m' 60
 
 -- | Find out how much time since midnight a given TimeOfDay is.
 timeOfDayToTime :: TimeOfDay -> DiffTime

--- a/lib/Data/Time/LocalTime/TimeZone.hs
+++ b/lib/Data/Time/LocalTime/TimeZone.hs
@@ -5,11 +5,11 @@
 -- #hide
 module Data.Time.LocalTime.TimeZone
 (
-	-- * Time zones
-	TimeZone(..),timeZoneOffsetString,timeZoneOffsetString',minutesToTimeZone,hoursToTimeZone,utc,
+    -- * Time zones
+    TimeZone(..),timeZoneOffsetString,timeZoneOffsetString',minutesToTimeZone,hoursToTimeZone,utc,
 
-	-- getting the locale time zone
-	getTimeZone,getCurrentTimeZone
+    -- getting the locale time zone
+    getTimeZone,getCurrentTimeZone
 ) where
 
 --import System.Time.Calendar.Format
@@ -31,12 +31,12 @@ import Data.Data
 
 -- | A TimeZone is a whole number of minutes offset from UTC, together with a name and a \"just for summer\" flag.
 data TimeZone = TimeZone {
-	-- | The number of minutes offset from UTC. Positive means local time will be later in the day than UTC.
-	timeZoneMinutes :: Int,
-	-- | Is this time zone just persisting for the summer?
-	timeZoneSummerOnly :: Bool,
-	-- | The name of the zone, typically a three- or four-letter acronym.
-	timeZoneName :: String
+    -- | The number of minutes offset from UTC. Positive means local time will be later in the day than UTC.
+    timeZoneMinutes :: Int,
+    -- | Is this time zone just persisting for the summer?
+    timeZoneSummerOnly :: Bool,
+    -- | The name of the zone, typically a three- or four-letter acronym.
+    timeZoneName :: String
 } deriving (Eq,Ord
 #if LANGUAGE_DeriveDataTypeable
 #if LANGUAGE_Rank2Types
@@ -46,7 +46,7 @@ data TimeZone = TimeZone {
     )
 
 instance NFData TimeZone where
-	rnf (TimeZone m so n) = m `deepseq` so `deepseq` n `deepseq` ()
+    rnf (TimeZone m so n) = m `deepseq` so `deepseq` n `deepseq` ()
 
 -- | Create a nameless non-summer timezone for this number of minutes
 minutesToTimeZone :: Int -> TimeZone
@@ -69,8 +69,8 @@ timeZoneOffsetString :: TimeZone -> String
 timeZoneOffsetString = timeZoneOffsetString' (Just '0')
 
 instance Show TimeZone where
-	show zone@(TimeZone _ _ "") = timeZoneOffsetString zone
-	show (TimeZone _ _ name) = name
+    show zone@(TimeZone _ _ "") = timeZoneOffsetString zone
+    show (TimeZone _ _ name) = name
 
 -- | The UTC time zone
 utc :: TimeZone
@@ -85,15 +85,15 @@ posixToCTime  = fromInteger . floor
 -- | Get the local time-zone for a given time (varying as per summertime adjustments)
 getTimeZone :: UTCTime -> IO TimeZone
 getTimeZone time = with 0 (\pdst -> with nullPtr (\pcname -> do
-	secs <- get_current_timezone_seconds (posixToCTime (utcTimeToPOSIXSeconds time)) pdst pcname
-	case secs of
-		0x80000000 -> fail "localtime_r failed"
-		_ -> do
-			dst <- peek pdst
-			cname <- peek pcname
-			name <- peekCString cname
-			return (TimeZone (div (fromIntegral secs) 60) (dst == 1) name)
-	))
+    secs <- get_current_timezone_seconds (posixToCTime (utcTimeToPOSIXSeconds time)) pdst pcname
+    case secs of
+        0x80000000 -> fail "localtime_r failed"
+        _ -> do
+            dst <- peek pdst
+            cname <- peek pcname
+            name <- peekCString cname
+            return (TimeZone (div (fromIntegral secs) 60) (dst == 1) name)
+    ))
 
 -- | Get the current time-zone
 getCurrentTimeZone :: IO TimeZone

--- a/time.cabal
+++ b/time.cabal
@@ -38,7 +38,7 @@ library
     build-depends:
         base >= 4.4 && < 5,
         deepseq >= 1.1
-    ghc-options: -Wall
+    ghc-options: -Wall -fwarn-tabs
     default-language: Haskell2010
     if impl(ghc)
         default-extensions:


### PR DESCRIPTION
This library is a GHC core library and GHC is now built using the
-fwarn-tabs flag by default. De-tabifying this brings it into line
with GHC standard practice.

Also add -fwarn-tabs to the cabal file.

Closes: https://github.com/haskell/time/issues/18
