### PR TITLE
Loosen required cabal-version

### DIFF
--- a/time.cabal
+++ b/time.cabal
@@ -11,7 +11,7 @@ synopsis:       A time library
 description:    A time library
 category:       System
 build-type:     Configure
-cabal-version:  >=1.14
+cabal-version:  >=1.10
 x-follows-version-policy:
 
 extra-source-files:


### PR DESCRIPTION
1.14 has the same features as 1.10 so this was overly restrictive and prevents anyone using the Cabal versions that ship with GHC <7.4.

