### PR TITLE
Fix compilation on GHC 7.0 by not using Trustworthy

### DIFF
--- a/lib/Data/Time/Clock/CTimeval.hs
+++ b/lib/Data/Time/Clock/CTimeval.hs
@@ -4,7 +4,7 @@ module Data.Time.Clock.CTimeval where
 #ifndef mingw32_HOST_OS
 -- All Unix-specific, this
 
-#if __GLASGOW_HASKELL__ >= 709
+#if __GLASGOW_HASKELL__ >= 709 || __GLASGOW_HASKELL__ < 702
 import Foreign
 #else
 import Foreign.Safe

--- a/lib/Data/Time/Clock/Scale.hs
+++ b/lib/Data/Time/Clock/Scale.hs
@@ -1,4 +1,6 @@
+#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
+#endif
 {-# OPTIONS -fno-warn-unused-imports #-}
 #include "HsConfigure.h"
 -- #hide
@@ -107,4 +109,3 @@ picosecondsToDiffTime x = fromRational (x % 1000000000000)
 "realToFrac/DiffTime->Pico"              realToFrac = \ (MkDiffTime ps) -> ps
 "realToFrac/Pico->DiffTime"              realToFrac = MkDiffTime
   #-}
-

--- a/lib/Data/Time/Clock/UTC.hs
+++ b/lib/Data/Time/Clock/UTC.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS -fno-warn-unused-imports #-}
+#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
+#endif
 #include "HsConfigure.h"
 -- #hide
 module Data.Time.Clock.UTC
@@ -122,4 +124,3 @@ instance RealFrac NominalDiffTime where
 "realToFrac/NominalDiffTime->Pico"       realToFrac = \ (MkNominalDiffTime ps) -> ps
 "realToFrac/Pico->NominalDiffTime"       realToFrac = MkNominalDiffTime
   #-}
-

--- a/lib/Data/Time/LocalTime/TimeZone.hs
+++ b/lib/Data/Time/LocalTime/TimeZone.hs
@@ -17,7 +17,7 @@ import Data.Time.Calendar.Private
 import Data.Time.Clock.POSIX
 import Data.Time.Clock.UTC
 
-#if __GLASGOW_HASKELL__ >= 709
+#if __GLASGOW_HASKELL__ >= 709 || __GLASGOW_HASKELL__ < 702
 import Foreign
 #else
 import Foreign.Safe

--- a/time.cabal
+++ b/time.cabal
@@ -48,7 +48,7 @@ library
             cpp-options: -DLANGUAGE_Rank2Types
     ghc-options: -Wall -fwarn-tabs
     build-depends:
-        base >= 4.4 && < 5,
+        base >= 4.3 && < 5,
         deepseq >= 1.1
     if os(windows)
         build-depends: Win32
@@ -149,4 +149,3 @@ test-suite tests
         Test.AddDays
         Test.AddDaysRef
         Test.TestUtil
-


### PR DESCRIPTION
This depends on doing something about 020ce40e69951849041349c0c38243e56169f572 to support GHC < 7.8.

Since time is so high up in the dependency tree it would be helpful to have a release that's compatible with older GHCs (and Cabals, #32).

