### PR TITLE
use clock_gettime to implement getPOSIXTime if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,8 @@ AC_CONFIG_HEADERS([lib/include/HsTimeConfig.h])
 AC_CHECK_HEADERS([time.h])
 AC_CHECK_FUNCS([gmtime_r localtime_r])
 
+AC_CHECK_FUNCS([clock_gettime])
+
 AC_STRUCT_TM
 AC_STRUCT_TIMEZONE
 

--- a/lib/Data/Time/Clock/CTimespec.hsc
+++ b/lib/Data/Time/Clock/CTimespec.hsc
@@ -1,0 +1,41 @@
+-- #hide
+module Data.Time.Clock.CTimespec where
+
+#include "HsTimeConfig.h"
+
+#if !defined(mingw32_HOST_OS) && HAVE_CLOCK_GETTIME
+
+#if __GLASGOW_HASKELL__ >= 709
+import Foreign
+#else
+import Foreign.Safe
+#endif
+import Foreign.C
+
+#include <time.h>
+
+data CTimespec = MkCTimespec CTime CLong
+
+instance Storable CTimespec where
+    sizeOf _ = #{size struct timespec}
+    alignment _ = alignment (undefined :: CLong)
+    peek p = do
+        s  <- #{peek struct timespec, tv_sec } p
+        ns <- #{peek struct timespec, tv_nsec} p
+        return (MkCTimespec s ns)
+    poke p (MkCTimespec s ns) = do
+        #{poke struct timespec, tv_sec } p s
+        #{poke struct timespec, tv_nsec} p ns
+
+foreign import ccall unsafe "time.h clock_gettime"
+    clock_gettime :: #{type clockid_t} -> Ptr CTimespec -> IO CInt
+
+-- | Get the current POSIX time from the system clock.
+getCTimespec :: IO CTimespec
+getCTimespec = alloca (\ptspec -> do
+    throwErrnoIfMinus1_ "clock_gettime" $
+        clock_gettime #{const CLOCK_REALTIME} ptspec
+    peek ptspec
+    )
+
+#endif

--- a/lib/Data/Time/Clock/POSIX.hs
+++ b/lib/Data/Time/Clock/POSIX.hs
@@ -10,9 +10,14 @@ import Data.Time.Calendar.Days
 import Data.Fixed
 import Control.Monad
 
+#include "HsTimeConfig.h"
+
 #ifdef mingw32_HOST_OS
 import Data.Word    ( Word64)
 import System.Win32.Time
+#elif HAVE_CLOCK_GETTIME
+import Data.Time.Clock.CTimespec
+import Foreign.C.Types (CTime(..))
 #else
 import Data.Time.Clock.CTimeval
 #endif
@@ -54,6 +59,15 @@ getPOSIXTime = do
 
 win32_epoch_adjust :: Word64
 win32_epoch_adjust = 116444736000000000
+
+#elif HAVE_CLOCK_GETTIME
+
+-- Use hi-res POSIX time
+ctimespecToPosixSeconds :: CTimespec -> POSIXTime
+ctimespecToPosixSeconds (MkCTimespec (CTime s) ns) =
+    (fromIntegral s) + (fromIntegral ns) / 1000000000
+
+getPOSIXTime = liftM ctimespecToPosixSeconds getCTimespec
 
 #else
 

--- a/time.cabal
+++ b/time.cabal
@@ -75,6 +75,7 @@ library
         Data.Time.Clock.Scale,
         Data.Time.Clock.UTC,
         Data.Time.Clock.CTimeval,
+        Data.Time.Clock.CTimespec,
         Data.Time.Clock.UTCDiff,
         Data.Time.LocalTime.TimeZone,
         Data.Time.LocalTime.TimeOfDay,


### PR DESCRIPTION
This addresses #36.

Some modern unix systems implement a function called `clock_gettime` which can be used to query to current time with nanosecond resolution. This PR enables `time` to conditionally use that function to implement `getCurrentTime`/`getPOSIXTime` on systems that support it. On other unix systems, it falls back to the old code path that relies on `gettimeofday` and offers microsecond resolution.

Note that linux supports nanosecond resolution for all timestamp operations. Over the past couple of years, the `unix` package was extended to expose the full timestamp resolution supported by linux. With this PR, we do the same thing for `time`.