### PR TITLE
Require GHC >= 7.10

### DIFF
--- a/time.cabal
+++ b/time.cabal
@@ -49,7 +49,7 @@ library
             cpp-options: -DLANGUAGE_Rank2Types
     ghc-options: -Wall -fwarn-tabs
     build-depends:
-        base >= 4.3 && < 5,
+        base >= 4.8 && < 5,
         deepseq >= 1.1
     if os(windows)
         build-depends: Win32


### PR DESCRIPTION
Build failure:
```
[19 of 26] Compiling Data.Time.Format.Parse ( lib/Data/Time/Format/Parse.hs, dist/dist-sandbox-3798890a/build/Data/Time/Format/Parse.o )

lib/Data/Time/Format/Parse.hs:524:32: Not in scope: ‘<$>’

lib/Data/Time/Format/Parse.hs:524:53: Not in scope: ‘<*>’

lib/Data/Time/Format/Parse.hs:587:32: Not in scope: ‘<$>’

lib/Data/Time/Format/Parse.hs:587:53: Not in scope: ‘<*>’

lib/Data/Time/Format/Parse.hs:590:37: Not in scope: ‘<$>’

lib/Data/Time/Format/Parse.hs:593:39: Not in scope: ‘<$>’
me packages failed to install:
time-1.6 failed during the building phase. The exception was:
ExitFailure 1
```

Matrix: http://matrix.hackage.haskell.org/package/time#GHC-7.8/time-1.6
Revision: https://hackage.haskell.org/package/time-1.6/revisions/

Since a revision has been applied there is no need for a new release unless you wish to recover support for older GHCs.
