### PR TITLE
Restore compat for GHC 7.8

### DIFF
--- a/lib/Data/Time/Format/Parse.hs
+++ b/lib/Data/Time/Format/Parse.hs
@@ -27,6 +27,9 @@ import Data.Time.LocalTime.TimeZone
 import Data.Time.LocalTime.TimeOfDay
 import Data.Time.LocalTime.LocalTime
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>),(<*>))
+#endif
 #if LANGUAGE_Rank2Types
 import Control.Monad
 #endif

--- a/time.cabal
+++ b/time.cabal
@@ -49,7 +49,7 @@ library
             cpp-options: -DLANGUAGE_Rank2Types
     ghc-options: -Wall -fwarn-tabs
     build-depends:
-        base >= 4.3 && < 5,
+        base >= 4.7 && < 5,
         deepseq >= 1.1
     if os(windows)
         build-depends: Win32


### PR DESCRIPTION
Restoring support for GHC 7.6 would require more work due to MkFixed

This renders #41 obsolete