### PR TITLE
Remove useless version bound on time.

### DIFF
--- a/time.cabal
+++ b/time.cabal
@@ -100,7 +100,7 @@ test-suite ShowDefaultTZAbbreviations
     ghc-options: -Wall -fwarn-tabs
     build-depends:
         base,
-        time == 1.8
+        time
     main-is: ShowDefaultTZAbbreviations.hs
 
 test-suite tests
@@ -122,7 +122,7 @@ test-suite tests
     build-depends:
         base,
         deepseq,
-        time == 1.8,
+        time,
         QuickCheck >= 2.5.1,
         test-framework >= 0.8,
         test-framework-quickcheck2 >= 0.3,


### PR DESCRIPTION
When build-depends refers to a library that is defined
in the same package, a version bound is not necessary:
the internal copy of the library is always preferred.
New versions of Cabal now warn in this case.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>