### PR TITLE
Added an example for parseTimeM

### DIFF
--- a/lib/Data/Time/Format/Parse.hs
+++ b/lib/Data/Time/Format/Parse.hs
@@ -92,6 +92,13 @@ class ParseTime t where
 --
 -- [@%0f@] accepts exactly two digits.
 --
+-- For example, to parse a date in YYYY-MM-DD format, while allowing the month 
+-- and date to have optional leading zeros (notice the @-@ modifier used for @%m@
+-- and @%d@:
+--
+-- > GHCi> parseTimeM True defaultTimeLocale "%Y-%-m-%-d" "2010-3-04" :: Either String Day
+-- > Right 2010-3-04
+-- 
 parseTimeM :: (Monad m,ParseTime t) =>
              Bool       -- ^ Accept leading and trailing whitespace?
           -> TimeLocale -- ^ Time locale.

--- a/lib/Data/Time/Format/Parse.hs
+++ b/lib/Data/Time/Format/Parse.hs
@@ -99,13 +99,6 @@ class ParseTime t where
 -- > GHCi> parseTimeM True defaultTimeLocale "%Y-%-m-%-d" "2010-3-04" :: Maybe Day
 -- > Just 2010-3-04
 -- 
--- __Caution:__ While you can use any Monad for 'parseTimeM', please be cautioned 
--- against using the 'Either' monad. When using the Either monad, if date/time parsing 
--- fails, a __runtime error__ with be thrown instead of evaluating to a 'Left' value. 
--- This is a known problem with the 'fail' implementation of 'Either' and doesn't necessarily
--- have anything to do with 'parseTimeM'. Alternatively, you may use 'Data.Aeson.Result' as the
--- base-monad for 'parseTimeM' to get back a 'Data.Aeson.Success' or 'Data.Aeson.Error' value.
--- 
 parseTimeM :: (Monad m,ParseTime t) =>
              Bool       -- ^ Accept leading and trailing whitespace?
           -> TimeLocale -- ^ Time locale.

--- a/lib/Data/Time/Format/Parse.hs
+++ b/lib/Data/Time/Format/Parse.hs
@@ -96,8 +96,15 @@ class ParseTime t where
 -- and date to have optional leading zeros (notice the @-@ modifier used for @%m@
 -- and @%d@:
 --
--- > GHCi> parseTimeM True defaultTimeLocale "%Y-%-m-%-d" "2010-3-04" :: Either String Day
--- > Right 2010-3-04
+-- > GHCi> parseTimeM True defaultTimeLocale "%Y-%-m-%-d" "2010-3-04" :: Maybe Day
+-- > Just 2010-3-04
+-- 
+-- __Caution:__ While you can use any Monad for 'parseTimeM', please be cautioned 
+-- against using the 'Either' monad. When using the Either monad, if date/time parsing 
+-- fails, a __runtime error__ with be thrown instead of evaluating to a 'Left' value. 
+-- This is a known problem with the 'fail' implementation of 'Either' and doesn't necessarily
+-- have anything to do with 'parseTimeM'. Alternatively, you may use 'Data.Aeson.Result' as the
+-- base-monad for 'parseTimeM' to get back a 'Data.Aeson.Success' or 'Data.Aeson.Error' value.
 -- 
 parseTimeM :: (Monad m,ParseTime t) =>
              Bool       -- ^ Accept leading and trailing whitespace?


### PR DESCRIPTION
It wasn't very clear how to parse date/month with optional `0` padding.