### PR TITLE
Adding subractUTCTime function

### DIFF
--- a/lib/Data/Time/Clock/Internal/UTCDiff.hs
+++ b/lib/Data/Time/Clock/Internal/UTCDiff.hs
@@ -8,6 +8,12 @@ import Data.Time.Clock.POSIX
 addUTCTime :: NominalDiffTime -> UTCTime -> UTCTime
 addUTCTime x t = posixSecondsToUTCTime (x + (utcTimeToPOSIXSeconds t))
 
+-- | subractUTCTime a b = b - a
+subractUTCTime :: NominalDiffTime -> UTCTime -> UTCTime
+subractUTCTime x t
+  | utcTimeToPOSIXSeconds t >= x = posixSecondsToUTCTime (utcTimeToPOSIXSeconds t - x)
+  | otherwise                    = posixSecondsToUTCTime 0
+
 -- | diffUTCTime a b = a - b
 diffUTCTime :: UTCTime -> UTCTime -> NominalDiffTime
 diffUTCTime a b = (utcTimeToPOSIXSeconds a) - (utcTimeToPOSIXSeconds b)


### PR DESCRIPTION
I have a use case for `subractUTCTime` to get past `UTCTime`. I felt having function in library instead of writing it by hand in my code. 
I am new to open source contributing. Please help me in adding test for `subractUTCTime` if it is necessary