### PR TITLE
Compatibility with GHC 8.6.1

### DIFF
--- a/lib/Data/Time/Calendar/CalendarDiffDays.hs
+++ b/lib/Data/Time/Calendar/CalendarDiffDays.hs
@@ -8,7 +8,7 @@ module Data.Time.Calendar.CalendarDiffDays
 #else
 import Data.Monoid
 #endif
-#if MIN_VERSION_base(4,9,0)
+#if MIN_VERSION_base(4,9,0) && !MIN_VERSION_base(4,12,0)
 import Data.Semigroup hiding (option)
 #endif
 

--- a/lib/Data/Time/LocalTime/Internal/CalendarDiffTime.hs
+++ b/lib/Data/Time/LocalTime/Internal/CalendarDiffTime.hs
@@ -7,7 +7,7 @@ module Data.Time.LocalTime.Internal.CalendarDiffTime
 #else
 import Data.Monoid
 #endif
-#if MIN_VERSION_base(4,9,0)
+#if MIN_VERSION_base(4,9,0) && !MIN_VERSION_base(4,12,0)
 import Data.Semigroup hiding (option)
 #endif
 import Data.Fixed


### PR DESCRIPTION
These imports of Data.Semigroup are redundant under base-4.12.0.0.