### PR TITLE
POSIX: Fix haddock links

### DIFF
--- a/lib/Data/Time/Clock/Internal/POSIXTime.hs
+++ b/lib/Data/Time/Clock/Internal/POSIXTime.hs
@@ -9,6 +9,6 @@ posixDayLength = nominalDay
 
 -- | POSIX time is the nominal time since 1970-01-01 00:00 UTC
 --
--- To convert from a 'Foreign.C.CTime' or 'System.Posix.EpochTime', use 'realToFrac'.
+-- To convert from a 'Foreign.C.Types.CTime' or @System.Posix.EpochTime@, use 'realToFrac'.
 --
 type POSIXTime = NominalDiffTime


### PR DESCRIPTION
You can't link to `System.Posix.EpochTime` since that module isn't imported, haddock will link it into nirvana.

`Foreign.C.CTime` didn't work because that just leads to e.g.
  http://hackage.haskell.org/package/base-4.11.1.0/docs/Foreign-C.html#v:CTime
which doesn't contain the function.