### PR TITLE
Add small example to documentation for NominalDiffTime.

### DIFF
--- a/lib/Data/Time/Clock/Internal/NominalDiffTime.hs
+++ b/lib/Data/Time/Clock/Internal/NominalDiffTime.hs
@@ -17,6 +17,7 @@ import Control.DeepSeq
 
 -- | This is a length of time, as measured by UTC.
 -- Conversion functions will treat it as seconds.
+-- For example, @(0.010 :: NominalDiffTime)@ corresponds to 10 milliseconds.
 -- It has a precision of 10^-12 s.
 -- It ignores leap-seconds, so it's not necessarily a fixed amount of clock time.
 -- For instance, 23:00 UTC + 2 hours of NominalDiffTime = 01:00 UTC (+ 1 day),


### PR DESCRIPTION
This also makes it immediately obvious how one can create a value of the type
out of thin air without crawling through the source code of the type class
instances.