### PR TITLE
Make DayOfWeek Ord

### DIFF
--- a/lib/Data/Time/Calendar/Week.hs
+++ b/lib/Data/Time/Calendar/Week.hs
@@ -16,7 +16,7 @@ data DayOfWeek
     | Friday
     | Saturday
     | Sunday
-    deriving (Eq, Show, Read, Data, Typeable)
+    deriving (Eq, Show, Read, Data, Typeable, Ord)
 
 -- | \"Circular\", so for example @[Tuesday ..]@ gives an endless sequence.
 -- Also: 'fromEnum' gives [1 .. 7] for [Monday .. Sunday], and 'toEnum' performs mod 7 to give a cycle of days.


### PR DESCRIPTION
Hey,

I have a use case in which I need to store `DayOfWeek`s in a hashmap. 
The hashmap implementation from the `containers` package requires `Ord`.

It looks like possible instances were discussed in #69, if I understand correctly `Ord` should not cause any issues ?
Let me know if I'm missing something