### PR TITLE
added subUTCTime

### DIFF
--- a/lib/Data/Time/Clock/Internal/UTCDiff.hs
+++ b/lib/Data/Time/Clock/Internal/UTCDiff.hs
@@ -8,6 +8,10 @@ import Data.Time.Clock.POSIX
 addUTCTime :: NominalDiffTime -> UTCTime -> UTCTime
 addUTCTime x t = posixSecondsToUTCTime (x + (utcTimeToPOSIXSeconds t))
 
+-- | subUTCTime a b = a - b
+subUTCTime :: UTCTime -> NominalDiffTime -> UTCTime
+subUTCTime t x = posixSecondsToUTCTime ((utcTimeToPOSIXSeconds t) - x)
+
 -- | diffUTCTime a b = a - b
 diffUTCTime :: UTCTime -> UTCTime -> NominalDiffTime
 diffUTCTime a b = (utcTimeToPOSIXSeconds a) - (utcTimeToPOSIXSeconds b)


### PR DESCRIPTION
This fills a gap not covered by the existing API; `diffUTCTime` only works with absolute `UTCTime`s, whereas this is similar to the behavior of `addUTCTime`, but subtracts instead of adds.