### PR TITLE
Fix Safe Haskell status

### DIFF
--- a/lib/Data/Format.hs
+++ b/lib/Data/Format.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Format
     ( Productish(..)
     , Summish(..)

--- a/lib/Data/Time.hs
+++ b/lib/Data/Time.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 {-|
 
 = Quick Start

--- a/lib/Data/Time/Calendar.hs
+++ b/lib/Data/Time/Calendar.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Calendar
     ( module Data.Time.Calendar.Days
     , module Data.Time.Calendar.CalendarDiffDays

--- a/lib/Data/Time/Calendar/CalendarDiffDays.hs
+++ b/lib/Data/Time/Calendar/CalendarDiffDays.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Calendar.CalendarDiffDays
     (
         -- * Calendar Duration

--- a/lib/Data/Time/Calendar/Easter.hs
+++ b/lib/Data/Time/Calendar/Easter.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Calendar.Easter
     ( sundayAfter
     , orthodoxPaschalMoon

--- a/lib/Data/Time/Calendar/Gregorian.hs
+++ b/lib/Data/Time/Calendar/Gregorian.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Safe #-}
 {-# OPTIONS -fno-warn-orphans #-}
 
 module Data.Time.Calendar.Gregorian

--- a/lib/Data/Time/Calendar/Julian.hs
+++ b/lib/Data/Time/Calendar/Julian.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Calendar.Julian
     ( Year
     , MonthOfYear

--- a/lib/Data/Time/Calendar/JulianYearDay.hs
+++ b/lib/Data/Time/Calendar/JulianYearDay.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Calendar.JulianYearDay
     (
     -- * Year and day format

--- a/lib/Data/Time/Calendar/Month.hs
+++ b/lib/Data/Time/Calendar/Month.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE Safe #-}
 #if __GLASGOW_HASKELL__ < 802
 {-# OPTIONS_GHC -Wno-incomplete-patterns -Wno-incomplete-uni-patterns #-}
 #endif

--- a/lib/Data/Time/Calendar/MonthDay.hs
+++ b/lib/Data/Time/Calendar/MonthDay.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Calendar.MonthDay
     ( MonthOfYear, DayOfMonth, DayOfYear
     , monthAndDayToDayOfYear

--- a/lib/Data/Time/Calendar/OrdinalDate.hs
+++ b/lib/Data/Time/Calendar/OrdinalDate.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 -- | ISO 8601 Ordinal Date format
 module Data.Time.Calendar.OrdinalDate (Day, Year, DayOfYear, WeekOfYear, module Data.Time.Calendar.OrdinalDate) where
 

--- a/lib/Data/Time/Calendar/Private.hs
+++ b/lib/Data/Time/Calendar/Private.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Calendar.Private where
 
 import Data.Fixed

--- a/lib/Data/Time/Calendar/Quarter.hs
+++ b/lib/Data/Time/Calendar/Quarter.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE Safe #-}
 #if __GLASGOW_HASKELL__ < 802
 {-# OPTIONS_GHC -Wno-incomplete-patterns -Wno-incomplete-uni-patterns #-}
 #endif

--- a/lib/Data/Time/Calendar/Types.hs
+++ b/lib/Data/Time/Calendar/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Calendar.Types where
 
 

--- a/lib/Data/Time/Calendar/Week.hs
+++ b/lib/Data/Time/Calendar/Week.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Calendar.Week
     (
       -- * Week

--- a/lib/Data/Time/Calendar/WeekDate.hs
+++ b/lib/Data/Time/Calendar/WeekDate.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 -- | Week-based calendars
 module Data.Time.Calendar.WeekDate
     (

--- a/lib/Data/Time/Clock.hs
+++ b/lib/Data/Time/Clock.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 -- | Types and functions for UTC and UT1
 module Data.Time.Clock
     ( module Data.Time.Clock.Internal.UniversalTime

--- a/lib/Data/Time/Format.hs
+++ b/lib/Data/Time/Format.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Format
     (
     -- * UNIX-style formatting

--- a/lib/Data/Time/Format/Format/Class.hs
+++ b/lib/Data/Time/Format/Format/Class.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Format.Format.Class
     (
         -- * Formatting

--- a/lib/Data/Time/Format/Format/Instances.hs
+++ b/lib/Data/Time/Format/Format/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Safe #-}
 {-# OPTIONS -fno-warn-orphans #-}
 #if __GLASGOW_HASKELL__ < 802
 {-# OPTIONS_GHC -Wno-incomplete-patterns -Wno-incomplete-uni-patterns #-}

--- a/lib/Data/Time/Format/ISO8601.hs
+++ b/lib/Data/Time/Format/ISO8601.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Format.ISO8601
     (
         -- * Format

--- a/lib/Data/Time/Format/Internal.hs
+++ b/lib/Data/Time/Format/Internal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 {-|
 The contents of this module is liable to change, or disappear entirely.
 Please <https://github.com/haskell/time/issues/new let me know> if you depend on anything here.

--- a/lib/Data/Time/Format/Locale.hs
+++ b/lib/Data/Time/Format/Locale.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 -- Note: this file derives from old-locale:System.Locale.hs, which is copyright (c) The University of Glasgow 2001
 module Data.Time.Format.Locale
     ( TimeLocale(..)

--- a/lib/Data/Time/Format/Parse.hs
+++ b/lib/Data/Time/Format/Parse.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Safe #-}
 {-# OPTIONS -fno-warn-orphans #-}
 
 module Data.Time.Format.Parse

--- a/lib/Data/Time/Format/Parse/Class.hs
+++ b/lib/Data/Time/Format/Parse/Class.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.Format.Parse.Class
     (
         -- * Parsing

--- a/lib/Data/Time/Format/Parse/Instances.hs
+++ b/lib/Data/Time/Format/Parse/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Safe #-}
 {-# OPTIONS -fno-warn-orphans #-}
 
 module Data.Time.Format.Parse.Instances

--- a/lib/Data/Time/LocalTime.hs
+++ b/lib/Data/Time/LocalTime.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.LocalTime
     (
     -- * Time zones

--- a/lib/Data/Time/LocalTime/Internal/CalendarDiffTime.hs
+++ b/lib/Data/Time/LocalTime/Internal/CalendarDiffTime.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.LocalTime.Internal.CalendarDiffTime
     (
         -- * Calendar Duration

--- a/lib/Data/Time/LocalTime/Internal/LocalTime.hs
+++ b/lib/Data/Time/LocalTime/Internal/LocalTime.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Safe #-}
 {-# OPTIONS -fno-warn-orphans #-}
 
 module Data.Time.LocalTime.Internal.LocalTime

--- a/lib/Data/Time/LocalTime/Internal/TimeOfDay.hs
+++ b/lib/Data/Time/LocalTime/Internal/TimeOfDay.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module Data.Time.LocalTime.Internal.TimeOfDay
     (
     -- * Time of day

--- a/lib/Data/Time/LocalTime/Internal/TimeZone.hs
+++ b/lib/Data/Time/LocalTime/Internal/TimeZone.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Safe #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 
 module Data.Time.LocalTime.Internal.TimeZone

--- a/lib/Data/Time/LocalTime/Internal/ZonedTime.hs
+++ b/lib/Data/Time/LocalTime/Internal/ZonedTime.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Safe #-}
 {-# OPTIONS -fno-warn-orphans #-}
 
 module Data.Time.LocalTime.Internal.ZonedTime


### PR DESCRIPTION
This fixes the `Safe` status of the `Data.Time.Calendar.Month` and `Data.Time.Calendar.Quarter` modules by dropping unnecessary (and somewhat confusing) uses of GNTD.