### PR TITLE
Resolve circular dependency in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,10 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
-# worarkound cyclic deps within testsuite
-# - cabal install . 'QuickCheck >= 2.5.1' 'test-framework >= 0.8' 'test-framework-quickcheck2' --force-reinstalls
  - cabal configure --disable-tests -v2  # -v2 provides useful information for debugging
  - cabal build --ghc-options="-Werror"   # this builds all libraries and executables (including tests/benchmarks)
-# - cabal test
+ - cabal configure --enable-tests -v2
+ - cabal test
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 

--- a/test/unix/Test/LocalTime/TimeZone.hs
+++ b/test/unix/Test/LocalTime/TimeZone.hs
@@ -3,7 +3,7 @@ module Test.LocalTime.TimeZone
     ) where
 
 import Data.Time
-import System.Posix.Env (putEnv)
+import System.Environment (setEnv)
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -11,8 +11,8 @@ testTimeZone :: TestTree
 testTimeZone =
     testCase "getTimeZone respects TZ env var" $ do
         let epoch = UTCTime (ModifiedJulianDay 57000) 0
-        putEnv "TZ=UTC+0"
+        setEnv "TZ" "UTC+0"
         zone1 <- getTimeZone epoch
-        putEnv "TZ=EST+5"
+        setEnv "TZ" "EST+5"
         zone2 <- getTimeZone epoch
         assertBool "zone not changed" $ zone1 /= zone2

--- a/time.cabal
+++ b/time.cabal
@@ -211,8 +211,6 @@ test-suite test-unix
         tasty,
         tasty-hunit,
         tasty-quickcheck
-    if !os(windows)
-        build-depends: unix
     main-is: Main.hs
     other-modules:
         Test.TestUtil


### PR DESCRIPTION
Closes #85. 

This should allow to test `time` using `cabal test`. It became possible because `tasty-1.4.0.1` features a flag to disable `unix` and transitively `time` dependencies.