### PR TITLE
Explain how NominalDiffTime works with LocalTime

### DIFF
--- a/lib/Data/Time/LocalTime/Internal/LocalTime.hs
+++ b/lib/Data/Time/LocalTime/Internal/LocalTime.hs
@@ -42,10 +42,14 @@ instance Show LocalTime where
     show (LocalTime d t) = (showGregorian d) ++ " " ++ (show t)
 
 -- | addLocalTime a b = a + b
+--
+-- Works by assuming the @LocalTime@s are in UTC.
 addLocalTime :: NominalDiffTime -> LocalTime -> LocalTime
 addLocalTime x = utcToLocalTime utc . addUTCTime x . localTimeToUTC utc
 
 -- | diffLocalTime a b = a - b
+--
+-- Works by assuming the @LocalTime@s are in UTC.
 diffLocalTime :: LocalTime -> LocalTime -> NominalDiffTime
 diffLocalTime a b = diffUTCTime (localTimeToUTC utc a) (localTimeToUTC utc b)
 


### PR DESCRIPTION
I couldn't understand how `NominalDiffTime` works with `LocalTime` without looking at the source code. I thought it would be helpful to add this comment to save future users from confusion.

(I'm not even completely convinced that `NominalDiffTime` *should* work with `LocalTime` at all; I would prefer the API to force explicit conversion to UTC, but that's another debate.)