### PR TITLE
[#179] Add property and unit tests for DayPeriod functions

### DIFF
--- a/test/main/Main.hs
+++ b/test/main/Main.hs
@@ -39,7 +39,7 @@ tests =
             , clipDates
             , convertBack
             , longWeekYears
-            , testHasDays
+            , testDayPeriod
             , testMonthDay
             , testMonthOfYear
             , testEaster


### PR DESCRIPTION
Based on the following [comment](https://github.com/haskell/time/issues/179#issuecomment-940155588) this PR adds some property and unit tests for functions that have `DayPeriod` as a type constraint.