### PR TITLE
Fix wasm32-wasi build support

### DIFF
--- a/lib/Data/Time/Clock/Internal/CTimespec.hsc
+++ b/lib/Data/Time/Clock/Internal/CTimespec.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE CApiFFI #-}
+
 module Data.Time.Clock.Internal.CTimespec where
 
 #include "HsTimeConfig.h"
@@ -49,8 +51,7 @@ clockGetTime clockid = alloca (\ptspec -> do
     peek ptspec
     )
 
-clock_REALTIME :: ClockID
-clock_REALTIME = #{const CLOCK_REALTIME}
+foreign import capi unsafe "time.h value CLOCK_REALTIME" clock_REALTIME :: ClockID
 
 clock_TAI :: Maybe ClockID
 clock_TAI =


### PR DESCRIPTION
`CLOCK_REALTIME` is not always a literal integer. One counter-example is wasi-libc, where it aliases an internal symbol and therefore is a pointer type. This makes it incompatible with hsc2hs #const, therefore we better use capi import here, which is guaranteed to work uniformly and fixes wasm32-wasi support.