### PR TITLE
Use base CClockId as ClockId type

### DIFF
--- a/.github/workflows/ci.wasm32.yml
+++ b/.github/workflows/ci.wasm32.yml
@@ -1,0 +1,39 @@
+name: ci-wasm32
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  ci-wasm32:
+    name: ci-wasm32
+    runs-on: ubuntu-20.04
+    steps:
+
+      - name: setup-proot
+        run: |
+          sudo apt install -y proot
+
+      - name: setup-ghc-wasm32-wasi
+        run: |
+          pushd $(mktemp -d)
+          curl -L https://github.com/tweag/ghc-wasm32-wasi/archive/refs/heads/master.tar.gz | tar xz --strip-components=1
+          ./setup.sh
+          ~/.ghc-wasm32-wasi/add_to_github_path.sh
+          popd
+
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: build
+        run: |
+          sed -i '/tasty/d' time.cabal
+
+          echo "package QuickCheck" >> cabal.project.local
+          echo "  flags: -templatehaskell" >> cabal.project.local
+
+          autoreconf -i
+
+          wasmtime-run wasm32-wasi-cabal run ShowDefaultTZAbbreviations
+          wasmtime-run wasm32-wasi-cabal run ShowTime

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ AC_CHECK_HEADERS([time.h])
 AC_CHECK_FUNCS([gmtime_r localtime_r])
 
 AC_CHECK_FUNCS([clock_gettime])
+AC_CHECK_FUNCS([tzset])
 
 AC_STRUCT_TM
 AC_STRUCT_TIMEZONE

--- a/lib/Data/Time/Clock/Internal/CTimespec.hsc
+++ b/lib/Data/Time/Clock/Internal/CTimespec.hsc
@@ -9,10 +9,11 @@ module Data.Time.Clock.Internal.CTimespec where
 import Foreign
 import Foreign.C
 import System.IO.Unsafe
+import System.Posix.Types
 
 #include <time.h>
 
-type ClockID = #{type clockid_t}
+type ClockID = CClockId
 
 data CTimespec = MkCTimespec CTime CLong
 
@@ -51,7 +52,7 @@ clockGetTime clockid = alloca (\ptspec -> do
     peek ptspec
     )
 
-foreign import capi unsafe "time.h value CLOCK_REALTIME" clock_REALTIME :: ClockID
+foreign import capi unsafe "HsTime.h value HS_CLOCK_REALTIME" clock_REALTIME :: ClockID
 
 clock_TAI :: Maybe ClockID
 clock_TAI =

--- a/lib/cbits/HsTime.c
+++ b/lib/cbits/HsTime.c
@@ -10,7 +10,7 @@ long int get_current_timezone_seconds (time_t t,int* pdst,char const* * pname)
     // as Microsoft considers the POSIX named `tzset()` function
     // deprecated (see http://msdn.microsoft.com/en-us/library/ms235384.aspx)
     _tzset();
-#else
+#elif defined(HAVE_TZSET)
     tzset();
 #endif
 

--- a/lib/include/HsTime.h
+++ b/lib/include/HsTime.h
@@ -18,6 +18,8 @@
 #include <time.h>
 #endif
 
+#define HS_CLOCK_REALTIME (uintptr_t)(CLOCK_REALTIME)
+
 long int get_current_timezone_seconds (time_t,int* pdst,char const* * pname);
 
 #endif


### PR DESCRIPTION
We used to define ClockId as hsc2hs-detected ${type clockid_t} type. Unfortunately, certain libcs (e.g. wasi-libc) define clockid_t as a pointer type, and hsc2hs only supports detecting C integral/floating-point types, so clockid_t will mistakenly be detected as a floating-point type, resulting in incorrect code generation.

We should really just use the base CClockId type here. base handles C pointer types correctly, since it uses its own custom autoconf logic instead of hsc2hs, and similar issues have been reported & fixed before, see https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6896 and https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6912.