### PR TITLE
Use capi for syscalls that break under musl's handling of 64-bit time_t

### DIFF
--- a/lib/Data/Time/Clock/Internal/CTimespec.hsc
+++ b/lib/Data/Time/Clock/Internal/CTimespec.hsc
@@ -28,9 +28,9 @@ instance Storable CTimespec where
         #{poke struct timespec, tv_sec } p s
         #{poke struct timespec, tv_nsec} p ns
 
-foreign import ccall unsafe "time.h clock_gettime"
+foreign import capi unsafe "time.h clock_gettime"
     clock_gettime :: ClockID -> Ptr CTimespec -> IO CInt
-foreign import ccall unsafe "time.h clock_getres"
+foreign import capi unsafe "time.h clock_getres"
     clock_getres :: ClockID -> Ptr CTimespec -> IO CInt
 
 -- | Get the resolution of the given clock.

--- a/lib/Data/Time/Clock/Internal/CTimeval.hs
+++ b/lib/Data/Time/Clock/Internal/CTimeval.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE CApiFFI #-}
 
 module Data.Time.Clock.Internal.CTimeval where
 
@@ -23,7 +24,7 @@ instance Storable CTimeval where
         pokeElemOff (castPtr p) 0 s
         pokeElemOff (castPtr p) 1 mus
 
-foreign import ccall unsafe "time.h gettimeofday" gettimeofday :: Ptr CTimeval -> Ptr () -> IO CInt
+foreign import capi unsafe "sys/time.h gettimeofday" gettimeofday :: Ptr CTimeval -> Ptr () -> IO CInt
 
 -- | Get the current POSIX time from the system clock.
 getCTimeval :: IO CTimeval


### PR DESCRIPTION
I maintain a [repo with builds of GHC](https://github.com/redneb/ghc-alt-libc) for the musl C standard library and I encountered a subtle bug of this library that affects GHC under 32-bit architectures with musl.

In 32-bit architectures, there was a transition where the C type `time_t` was redefined to be 64-bit in order to address the Y2038 problem. The way this was handled by musl was by introducing new versions of all affected syscalls that work with 64-bit `time_t` (e.g. `__clock_gettime64` is like `clock_gettime` but with 64-bit `time_t`). In addition, a redirect was introduced to create an alias of the new versions of these functions under the old name (e.g. [here's the redirection](https://git.musl-libc.org/cgit/musl/tree/include/time.h?id=dc9285ad1dc19349c407072cc48ba70dab86de45#n151) for `clock_gettime`).

The problem is that this redirection is defined as a C macro in a C header file and as such, it does not get picked by GHC when the foreign function import is done via `ccall`, but works just fine when `capi` is used. So this PR changes all affected syscalls to be imported with `capi`, which should be a fairly uncontroversial change.