### PR TITLE
converting picoseconds to micro and milliseconds

### DIFF
--- a/lib/Data/Time/Clock/Internal/DiffTime.hs
+++ b/lib/Data/Time/Clock/Internal/DiffTime.hs
@@ -9,6 +9,8 @@ module Data.Time.Clock.Internal.DiffTime (
     secondsToDiffTime,
     picosecondsToDiffTime,
     diffTimeToPicoseconds,
+    diffTimeToMicroseconds,
+    diffTimeToMilliseconds
 ) where
 
 import Control.DeepSeq
@@ -92,6 +94,12 @@ picosecondsToDiffTime x = MkDiffTime (MkFixed x)
 -- | Get the number of picoseconds in a 'DiffTime'.
 diffTimeToPicoseconds :: DiffTime -> Integer
 diffTimeToPicoseconds (MkDiffTime (MkFixed x)) = x
+
+diffTimeToMicroseconds :: DiffTime -> Integer
+diffTimeToMicroseconds diffTime = quot (diffTimeToPicoseconds diffTime) 1000000
+
+diffTimeToMilliseconds :: DiffTime -> Integer
+diffTimeToMilliseconds diffTime = quot (diffTimeToPicoseconds diffTime) 1000000000
 
 {-# RULES
 "realToFrac/DiffTime->Pico" realToFrac = \(MkDiffTime ps) -> ps


### PR DESCRIPTION
There is only one function which converts `DiffTime` into numeric value which is `diffTimeToPicoseconds`. I don't see any reason to distinguish picoseconds from the other time measurement units. Lot of other libs in the Haskell's ecosystem accepts _microseconds_ (e.g. `threadDelay` from `Control.Concurrent`). Of course it is very easy to do the conversions on its own, but I think we should pull this out in front of the parentheses (and it is the right place to do so). My proposal is to add two other conversions which are `diffTimeToMicroseconds` and `diffTimeToMilliseconds`.