### PR TITLE
Keep Pico unit explicit when converting to and from `DiffTime`

### DIFF
--- a/lib/Data/Time/Clock/Internal/DiffTime.hs
+++ b/lib/Data/Time/Clock/Internal/DiffTime.hs
@@ -86,12 +86,12 @@ secondsToDiffTime :: Integer -> DiffTime
 secondsToDiffTime = fromInteger
 
 -- | Create a 'DiffTime' from a number of picoseconds.
-picosecondsToDiffTime :: Integer -> DiffTime
-picosecondsToDiffTime x = MkDiffTime (MkFixed x)
+picosecondsToDiffTime :: Pico -> DiffTime
+picosecondsToDiffTime = MkDiffTime
 
 -- | Get the number of picoseconds in a 'DiffTime'.
-diffTimeToPicoseconds :: DiffTime -> Integer
-diffTimeToPicoseconds (MkDiffTime (MkFixed x)) = x
+diffTimeToPicoseconds :: DiffTime -> Pico
+diffTimeToPicoseconds (MkDiffTime x) = x
 
 {-# RULES
 "realToFrac/DiffTime->Pico" realToFrac = \(MkDiffTime ps) -> ps


### PR DESCRIPTION
The conversion of picoseconds to and from `DiffTime` doesn't keep the unit explicit. Which can be confusing and is not homogeneous with the same conversion, but to and from `NominalDiffTime`. This is a very simple PR to make the API more consistent. 