### PR TITLE
Fixes for wasm/js backend

### DIFF
--- a/.github/workflows/ci.wasm32.yml
+++ b/.github/workflows/ci.wasm32.yml
@@ -1,26 +1,22 @@
 name: ci-wasm32
 
 on:
-  push:
-  pull_request:
+  push: {}
+  pull_request: {}
 
 jobs:
 
   ci-wasm32:
     name: ci-wasm32
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
-      - name: setup-proot
-        run: |
-          sudo apt install -y proot
-
-      - name: setup-ghc-wasm32-wasi
+      - name: setup-wasm32-wasi-ghc
         run: |
           pushd $(mktemp -d)
-          curl -L https://github.com/tweag/ghc-wasm32-wasi/archive/refs/heads/master.tar.gz | tar xz --strip-components=1
-          ./setup.sh
-          ~/.ghc-wasm32-wasi/add_to_github_path.sh
+          curl -f -L --retry 5 https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/archive/master/ghc-wasm-meta-master.tar.gz | tar xz --strip-components=1
+          FLAVOUR=9.6 PREFIX=/tmp/.ghc-wasm ./setup.sh
+          /tmp/.ghc-wasm/add_to_github_path.sh
           popd
 
       - name: checkout
@@ -35,5 +31,8 @@ jobs:
 
           autoreconf -i
 
-          wasmtime-run wasm32-wasi-cabal run ShowDefaultTZAbbreviations
-          wasmtime-run wasm32-wasi-cabal run ShowTime
+          wasm32-wasi-cabal build test:ShowDefaultTZAbbreviations
+          wasmtime run $(wasm32-wasi-cabal list-bin test:ShowDefaultTZAbbreviations)
+
+          wasm32-wasi-cabal build test:ShowTime
+          wasmtime run $(wasm32-wasi-cabal list-bin test:ShowTime)

--- a/lib/Data/Time/Clock/Internal/CTimespec.hsc
+++ b/lib/Data/Time/Clock/Internal/CTimespec.hsc
@@ -1,4 +1,6 @@
+#if !defined(javascript_HOST_ARCH)
 {-# LANGUAGE CApiFFI #-}
+#endif
 
 module Data.Time.Clock.Internal.CTimespec where
 
@@ -52,7 +54,13 @@ clockGetTime clockid = alloca (\ptspec -> do
     peek ptspec
     )
 
+#if defined(javascript_HOST_ARCH)
+-- JS backend doesn't support foreign imports with capi convention
+clock_REALTIME :: ClockID
+clock_REALTIME = #{const CLOCK_REALTIME}
+#else
 foreign import capi unsafe "HsTime.h value HS_CLOCK_REALTIME" clock_REALTIME :: ClockID
+#endif
 
 clock_TAI :: Maybe ClockID
 clock_TAI =


### PR DESCRIPTION
- Add a fix for the JS backend cherry-picked from https://gitlab.haskell.org/ghc/packages/time/-/tree/wip/js-clock
- Fix the wasm32 ci job. Apologies for not noticing the failure some time ago :/