### PR TITLE
Finish remaining fixes for the JS backend

### DIFF
--- a/lib/Data/Time/Clock/Internal/CTimespec.hsc
+++ b/lib/Data/Time/Clock/Internal/CTimespec.hsc
@@ -30,10 +30,21 @@ instance Storable CTimespec where
         #{poke struct timespec, tv_sec } p s
         #{poke struct timespec, tv_nsec} p ns
 
+#if defined(javascript_HOST_ARCH)
+
+foreign import ccall unsafe "time.h clock_gettime"
+    clock_gettime :: ClockID -> Ptr CTimespec -> IO CInt
+foreign import ccall unsafe "time.h clock_getres"
+    clock_getres :: ClockID -> Ptr CTimespec -> IO CInt
+
+#else
+
 foreign import capi unsafe "time.h clock_gettime"
     clock_gettime :: ClockID -> Ptr CTimespec -> IO CInt
 foreign import capi unsafe "time.h clock_getres"
     clock_getres :: ClockID -> Ptr CTimespec -> IO CInt
+
+#endif
 
 -- | Get the resolution of the given clock.
 clockGetRes :: ClockID -> IO (Either Errno CTimespec)

--- a/lib/Data/Time/Clock/Internal/CTimeval.hs
+++ b/lib/Data/Time/Clock/Internal/CTimeval.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE Safe #-}
+#if !defined(javascript_HOST_ARCH)
+{-# LANGUAGE CApiFFI #-}
+#endif
 
 module Data.Time.Clock.Internal.CTimeval where
 
@@ -24,7 +26,15 @@ instance Storable CTimeval where
         pokeElemOff (castPtr p) 0 s
         pokeElemOff (castPtr p) 1 mus
 
+#if defined(javascript_HOST_ARCH)
+
+foreign import ccall unsafe "sys/time.h gettimeofday" gettimeofday :: Ptr CTimeval -> Ptr () -> IO CInt
+
+#else
+
 foreign import capi unsafe "sys/time.h gettimeofday" gettimeofday :: Ptr CTimeval -> Ptr () -> IO CInt
+
+#endif
 
 -- | Get the current POSIX time from the system clock.
 getCTimeval :: IO CTimeval


### PR DESCRIPTION
The JS backend doesn't support capi calling convention for the time being. This patch delivers the remaining fixes, and is indeed tested to fix the compilation error via a ghc validate pipeline at https://gitlab.haskell.org/ghc/ghc/-/pipelines/65327.