### PR TITLE
Keep Pico unit explicit when converting to and from DiffTime

### DIFF
--- a/lib/Data/Time/Clock/Internal/DiffTime.hs
+++ b/lib/Data/Time/Clock/Internal/DiffTime.hs
@@ -7,8 +7,7 @@ module Data.Time.Clock.Internal.DiffTime (
     -- * Absolute intervals
     DiffTime,
     secondsToDiffTime,
-    picosecondsToDiffTime,
-    diffTimeToPicoseconds,
+    diffTimeToSeconds,
 ) where
 
 import Control.DeepSeq
@@ -82,16 +81,12 @@ instance TH.Lift DiffTime where
     liftTyped (MkDiffTime (MkFixed a)) = [||MkDiffTime (MkFixed $$(TH.liftTyped a))||]
 
 -- | Create a 'DiffTime' which represents an integral number of seconds.
-secondsToDiffTime :: Integer -> DiffTime
-secondsToDiffTime = fromInteger
-
--- | Create a 'DiffTime' from a number of picoseconds.
-picosecondsToDiffTime :: Integer -> DiffTime
-picosecondsToDiffTime x = MkDiffTime (MkFixed x)
+secondsToDiffTime :: Pico -> DiffTime
+secondsToDiffTime = MkDiffTime
 
 -- | Get the number of picoseconds in a 'DiffTime'.
-diffTimeToPicoseconds :: DiffTime -> Integer
-diffTimeToPicoseconds (MkDiffTime (MkFixed x)) = x
+diffTimeToSeconds :: DiffTime -> Pico
+diffTimeToSeconds (MkDiffTime x) = x
 
 {-# RULES
 "realToFrac/DiffTime->Pico" realToFrac = \(MkDiffTime ps) -> ps

--- a/lib/Data/Time/Clock/System.hs
+++ b/lib/Data/Time/Clock/System.hs
@@ -11,6 +11,7 @@ module Data.Time.Clock.System (
     systemToTAITime,
 ) where
 
+import Data.Fixed (Fixed (..))
 import Data.Int (Int64)
 import Data.Time.Calendar.Days
 import Data.Time.Clock.Internal.AbsoluteTime
@@ -38,7 +39,7 @@ systemToUTCTime (MkSystemTime seconds nanoseconds) = let
     timePicoseconds :: Int64
     timePicoseconds = timeNanoseconds * 1000
     time :: DiffTime
-    time = picosecondsToDiffTime $ fromIntegral timePicoseconds
+    time = secondsToDiffTime $ MkFixed $ fromIntegral timePicoseconds
     in UTCTime day time
 
 -- | Convert 'UTCTime' to 'SystemTime', matching zero 'SystemTime' to midnight of 'systemEpochDay' UTC.
@@ -47,7 +48,7 @@ utcToSystemTime (UTCTime day time) = let
     days :: Int64
     days = fromIntegral $ diffDays day systemEpochDay
     timePicoseconds :: Int64
-    timePicoseconds = fromIntegral $ diffTimeToPicoseconds time
+    timePicoseconds = (\(MkFixed x) -> fromIntegral x) $ diffTimeToSeconds time
     timeNanoseconds :: Int64
     timeNanoseconds = timePicoseconds `div` 1000
     timeSeconds :: Int64


### PR DESCRIPTION
(Re-submitting a patched #237, inlining the description for convenience)

The conversion of picoseconds to and from `DiffTime` doesn't keep the unit explicit. Which can be confusing and is not homogeneous with the same conversion, but to and from `NominalDiffTime`. This is a very simple PR to make the API a little more consistent.

@AshleyYakeley, if this is still not correct, please let me know, I'm happy to fix it :)