### PR TITLE
Update lower bounds (base, template-haskell)

### DIFF
--- a/time.cabal
+++ b/time.cabal
@@ -52,9 +52,9 @@ library
     ghc-options: -Wall -fwarn-tabs
     c-sources: lib/cbits/HsTime.c
     build-depends:
-        base >= 4.14 && < 5,
+        base >= 4.15 && < 5,
         deepseq >= 1.1,
-        template-haskell >= 2.16,
+        template-haskell >= 2.17,
     if os(windows)
         build-depends: Win32
     exposed-modules:


### PR DESCRIPTION
This PR updates the following lower bounds:

  template-haskell: 2.16 -> 2.17
  base: 4.14 -> 4.15

This ensures we don't try to build time >= 1.14 with GHC 8.10 or below,
which is not supported:

  lib\Data\Time\Clock\Internal\DiffTime.hs:83:18: error:
  Error:     Not in scope: type constructor or class ‘TH.Quote’

  lib\Data\Time\Clock\Internal\DiffTime.hs:83:44: error:
  Error:     Not in scope: type constructor or class ‘TH.Code’

I believe this should be applied as a Hackage revision to the package as well.