### PR TITLE
Hide Data.Time.Format.Internal module

### DIFF
--- a/test/main/Test/Format/ISO8601.hs
+++ b/test/main/Test/Format/ISO8601.hs
@@ -4,10 +4,10 @@ module Test.Format.ISO8601 (
     testISO8601,
 ) where
 
+import Data.Coerce
 import Data.Ratio
 import Data.Time
 import Data.Time.Format.ISO8601
-import Data.Time.Format.Internal
 import Test.Arbitrary ()
 import Test.QuickCheck.Property
 import Test.Tasty
@@ -57,7 +57,7 @@ readShowTestsCheck skip fmts = readBoth $ \fe -> readShowTestCheck skip $ fmts f
 readShowTests :: (Eq a, Show a, Arbitrary a, SpecialTestValues a) => (FormatExtension -> Format a) -> [TestTree]
 readShowTests = readShowTestsCheck $ \_ -> False
 
-newtype Durational t = MkDurational {unDurational :: t}
+newtype Durational t = MkDurational t
     deriving (Eq)
 
 instance Show t => Show (Durational t) where
@@ -81,7 +81,7 @@ instance Arbitrary (Durational CalendarDiffTime) where
                 return $ MkDurational $ CalendarDiffTime mm $ fromRational $ ss % picofactor
 
 durationalFormat :: Format a -> Format (Durational a)
-durationalFormat (MkFormat sa ra) = MkFormat (\b -> sa $ unDurational b) (fmap MkDurational ra)
+durationalFormat = coerce
 
 testReadShowFormat :: TestTree
 testReadShowFormat =

--- a/time.cabal
+++ b/time.cabal
@@ -73,7 +73,6 @@ library
         Data.Time.Clock.TAI,
         Data.Time.LocalTime,
         Data.Time.Format,
-        Data.Time.Format.Internal,
         Data.Time.Format.ISO8601,
         Data.Time
     other-modules:
@@ -85,6 +84,7 @@ library
         Data.Time.Calendar.Private,
         Data.Time.Calendar.Types,
         Data.Time.Calendar.Week,
+        Data.Time.Format.Internal,
         Data.Time.Clock.Internal.DiffTime,
         Data.Time.Clock.Internal.AbsoluteTime,
         Data.Time.Clock.Internal.NominalDiffTime,


### PR DESCRIPTION
As the module contents are subject to change or disappear entirely; let's hide it.

It's was in fact used in tests, so arguably it was needed; but the usecase is easy, there we can `coerce` the `Format a` to `Format (Durational a)`.