### PR TITLE
Avoid partial functions Data.List.init and Data.List.last

### DIFF
--- a/lib/Data/Format.hs
+++ b/lib/Data/Format.hs
@@ -227,11 +227,11 @@ zeroPad Nothing s = s
 zeroPad (Just i) s = replicate (i - length s) '0' ++ s
 
 trimTrailing :: String -> String
-trimTrailing "" = ""
-trimTrailing "." = ""
-trimTrailing s
-    | last s == '0' = trimTrailing $ init s
-trimTrailing s = s
+trimTrailing
+    = (\s -> if s == "." then "" else s)
+    . reverse
+    . dropWhile (== '0')
+    . reverse
 
 showNumber :: Show t => SignOption -> Maybe Int -> t -> Maybe String
 showNumber signOpt mdigitcount t =


### PR DESCRIPTION
This is to comply with https://github.com/haskell/core-libraries-committee/issues/292