### PR TITLE
Fix typos in documentation and tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # time
 
-This is the haskell time library that is bundled with [GHC][GHC] the Glasgow/
-Glorious Haskell compiler.
+This is the Haskell time library that is bundled with [GHC][GHC], the
+Glasgow/Glorious Haskell compiler.
 
 To build this package using Cabal directly from git, you must run
 "autoreconf" before the usual Cabal build steps (configure/build/install).

--- a/test/main/Test/Calendar/CalendarProps.hs
+++ b/test/main/Test/Calendar/CalendarProps.hs
@@ -21,4 +21,4 @@ testYearQuarter = nameTest "YearQuarter" $ \q -> case q of
     YearQuarter y qy -> q == YearQuarter y qy
 
 testCalendarProps :: TestTree
-testCalendarProps = nameTest "calender-props" [testYearMonth, testMonthDay, testYearQuarter]
+testCalendarProps = nameTest "calendar-props" [testYearMonth, testMonthDay, testYearQuarter]

--- a/test/main/Test/Format/Format.hs
+++ b/test/main/Test/Format/Format.hs
@@ -163,20 +163,20 @@ testDiffTime =
         , testAFormat "%3ES" "01.245" (61.24582 :: DiffTime)
         ]
 
-testCalenderDiffDays :: TestTree
-testCalenderDiffDays =
+testCalendarDiffDays :: TestTree
+testCalendarDiffDays =
     testGroup
-        "CalenderDiffDays"
+        "CalendarDiffDays"
         [ testAFormat "%yy%Bm%ww%Dd" "5y4m3w2d" $ CalendarDiffDays 64 23
         , testAFormat "%bm %dd" "64m 23d" $ CalendarDiffDays 64 23
         , testAFormat "%yy%Bm%ww%Dd" "-5y-4m-3w-2d" $ CalendarDiffDays (-64) (-23)
         , testAFormat "%bm %dd" "-64m -23d" $ CalendarDiffDays (-64) (-23)
         ]
 
-testCalenderDiffTime :: TestTree
-testCalenderDiffTime =
+testCalendarDiffTime :: TestTree
+testCalendarDiffTime =
     testGroup
-        "CalenderDiffTime"
+        "CalendarDiffTime"
         [ testAFormat "%yy%Bm%ww%Dd%Hh%Mm%Ss" "5y4m3w2d2h22m8s" $ CalendarDiffTime 64 $ 23 * 86400 + 8528.21
         , testAFormat "%yy%Bm%ww%Dd%Hh%Mm%ESs" "5y4m3w2d2h22m8.21s" $ CalendarDiffTime 64 $ 23 * 86400 + 8528.21
         , testAFormat "%yy%Bm%ww%Dd%Hh%Mm%0ESs" "5y4m3w2d2h22m08.210000000000s" $
@@ -207,6 +207,6 @@ testFormat =
         , testTimeZone
         , testNominalDiffTime
         , testDiffTime
-        , testCalenderDiffDays
-        , testCalenderDiffTime
+        , testCalendarDiffDays
+        , testCalendarDiffTime
         ]

--- a/test/main/Test/Format/ParseTime.hs
+++ b/test/main/Test/Format/ParseTime.hs
@@ -565,7 +565,7 @@ typedTests prop =
     , nameTest "UTCTime" $ tgroup utcTimeAlmostFormats $ \fmt t -> utctDayTime t < 86400 ==> prop fmt t
     , nameTest "UniversalTime" $ tgroup universalTimeFormats prop
     , nameTest "CalendarDiffDays" $ tgroup calendarDiffDaysFormats prop
-    , nameTest "CalenderDiffTime" $ tgroup calendarDiffTimeFormats prop
+    , nameTest "CalendarDiffTime" $ tgroup calendarDiffTimeFormats prop
     , nameTest "DiffTime" $ tgroup diffTimeFormats prop
     , nameTest "NominalDiffTime" $ tgroup nominalDiffTimeFormats prop
     ]


### PR DESCRIPTION
## Summary
- fix Haskell capitalization in `Readme.md`
- correct several `Calendar`-related spellings in the test suite

## Testing
- `cabal test` *(fails: command not found)*
- `stack test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bb6d90f6c832184fef0a550fe69a9