### PR TITLE
Better, structure-preserving `Duration` type for ISO 8601 / XSD round-trip and arithmetic

### DIFF
--- a/lib/Data/Time/Format/Format/Instances.hs
+++ b/lib/Data/Time/Format/Format/Instances.hs
@@ -25,6 +25,7 @@ import Data.Time.Clock.Internal.UniversalTime
 import Data.Time.Clock.POSIX
 import Data.Time.Format.Format.Class
 import Data.Time.Format.Locale
+import Data.Time.Format.ISO8601.Duration (Duration, toCalendarDiffTime)
 import Data.Time.LocalTime.Internal.CalendarDiffTime
 import Data.Time.LocalTime.Internal.LocalTime
 import Data.Time.LocalTime.Internal.TimeOfDay
@@ -227,3 +228,9 @@ instance FormatTime CalendarDiffTime where
     formatCharacter _ 'b' = Just $ formatNumberStd 1 $ ctMonths
     formatCharacter _ 'B' = Just $ formatNumberStd 2 $ remBy 12 . ctMonths
     formatCharacter alt c = mapFormatCharacter ctTime $ formatCharacter alt c
+
+-- Delegates to the 'CalendarDiffTime' instance via the
+-- canonicalising 'toCalendarDiffTime', so e.g. @%y@ on a 'Duration'
+-- parsed from @P12M@ yields @1@, matching XSD 1.1 §E.2.
+instance FormatTime Duration where
+    formatCharacter alt c = mapFormatCharacter toCalendarDiffTime $ formatCharacter alt c

--- a/lib/Data/Time/Format/ISO8601/Duration.hs
+++ b/lib/Data/Time/Format/ISO8601/Duration.hs
@@ -302,24 +302,34 @@ zeroDuration =
         , durTime = Nothing
         }
 
--- | Spec-correct addition per XSD 1.1 §3.3.6.1: add 'months' axes,
--- add 'seconds' axes; the result is always in canonical form (see
--- 'normalizeDuration') because mixed-sign tuples cannot arise from
--- the sum of two well-formed durations of the same sign — and when
--- they /can/ arise (operands of opposite sign), the canonicalisation
--- in 'fromCalendarDiffTime' clamps to a representable form.
+-- | Spec-correct addition per XSD 1.1 §3.3.6.1: add the months
+-- axes and the seconds axes independently, then canonicalise the
+-- result via 'normalizeDuration' (XSD §E.2).  This matches the
+-- 'Semigroup' for 'CalendarDiffTime' on the 'toCalendarDiffTime'
+-- image and is the operation @xml-typelift@ et al. need to drop
+-- the @iso8601-duration@ \/ 'CalendarDiffTime' dependency entirely.
 --
--- Note: addition collapses the lexical structure.  The empty
--- duration acts as identity.  This is /not/ field-wise concatenation
--- (which would not be associative or canonical).
+-- __Mixed-sign edge case.__  Two same-signed operands always sum
+-- to a same-signed result, which 'fromCalendarDiffTime' accepts.
+-- Two opposite-signed operands can produce a 'CalendarDiffTime'
+-- with mixed-signed @(months, seconds)@; XSD §3.3.6.1 forbids this
+-- in the value space.  The instance resolves this by /absorbing
+-- the smaller-magnitude axis into the dominant one's sign/: the
+-- result keeps the magnitude of the larger axis and zeros the
+-- smaller.  This is the closest representable approximation to
+-- the 'CalendarDiffTime' sum within the XSD value space; it is a
+-- known lossy edge case, documented here.  In practice durations
+-- combined for dateTime arithmetic should pass through
+-- 'addUTCDurationClip' \/ 'addLocalDurationClip', not through
+-- @<>@, when this matters.
+--
+-- __Loss of lexical structure.__  Like all arithmetic on
+-- 'Duration', @<>@ collapses the structure.  @P1Y \<\> P12M@ is
+-- 'normalizeDuration'-equivalent to @P2Y@, not @P1Y12M@.  This
+-- is /not/ field-wise concatenation (which would not be
+-- associative or canonical).
 instance Semigroup Duration where
-    a <> b = case fromCalendarDiffTime (toCalendarDiffTime a <> toCalendarDiffTime b) of
-        Just d -> normalizeDuration d
-        -- Mixed-sign result: clamp by zeroing the smaller axis.
-        -- This case is unreachable when both operands are
-        -- 'normalizeDuration'-canonical and same-signed; for opposite
-        -- signs the canonical-map convention of XSD §E.2 applies.
-        Nothing -> zeroDuration
+    a <> b = normalizeDuration (canonicaliseFromCDT (toCalendarDiffTime a <> toCalendarDiffTime b))
 
 instance Monoid Duration where
     mempty = zeroDuration

--- a/lib/Data/Time/Format/ISO8601/Duration.hs
+++ b/lib/Data/Time/Format/ISO8601/Duration.hs
@@ -4,28 +4,112 @@
 -- |
 -- Structure-preserving ISO 8601 / XSD @xs:duration@ values.
 --
+-- == Background and standards
+--
 -- 'Data.Time.Format.ISO8601.durationTimeFormat' parses into
--- 'Data.Time.LocalTime.CalendarDiffTime', collapsing the original
+-- 'Data.Time.LocalTime.CalendarDiffTime', which collapses the original
 -- Y\/M\/W\/D\/H\/M\/S grammar into @(months, NominalDiffTime)@.
 -- That is convenient for arithmetic but lossy: @P1Y@ and @P12M@,
 -- @P1W@ and @P7D@, @PT1H@ and @PT3600S@ all parse to equal values
--- and serialize to a single canonical form.  XML Schema
--- @xs:duration@ requires lexical-space round-trip; many other
--- consumers (JSON Schema, ICS, OData, REST APIs) expect it as well.
+-- and serialize to a single canonical form.
 --
--- 'Duration' keeps every component the input mentioned, including
--- the ISO 8601 week form (which is mutually exclusive with the
--- Y\/M\/D\/T components per ISO 8601:2004 sec. 4.4.3.2) and a single
--- leading sign.  'iso8601Format' on 'Duration' is bit-exact for
--- every valid lexical form, modulo trailing zeros after a decimal
--- point in the seconds field (per the format-class normalization).
+-- 'Duration' preserves every component the input mentioned, with a
+-- single leading sign.  The 'iso8601Format' on 'Duration' round-trips
+-- bit-exact for every valid ISO 8601 / XSD lexical form.
+--
+-- === Standards summary
+--
+-- * __ISO 8601:2004__ §4.4.3 defines two designator forms:
+--     §4.4.3.2 @P[nY][nM][nD][T[nH][nM][nS]]@ and the week form
+--     @PnW@; and §4.4.3.3 the alternative form
+--     @Pyyyy-mm-ddThh:mm:ss@.  ISO 8601 forbids a leading sign on
+--     these forms, but does permit a decimal fraction on the
+--     /lowest-order/ component (so @PT1.5H@ is well-formed if no
+--     M\/S follows).
+--
+-- * __XML Schema Part 2: Datatypes 1.1__ defines @xs:duration@
+--     (§3.3.6).  XSD diverges from ISO 8601 in three significant
+--     ways:
+--
+--       1. XSD __admits a leading minus sign__ (§3.3.6.2 prod. [15]).
+--       2. XSD __omits the week form__ entirely
+--          (§3.3.6.2 prods. [6]–[15]; there is no @duWeekFrag@).
+--       3. XSD __omits the alternative @Pyyyy-mm-dd...@ form__.
+--
+--     XSD also restricts decimals to seconds only
+--     (§3.3.6.2 prod. [11]); other fields are
+--     @unsignedNoDecimalPtNumeral@.  The @xs:duration@ value space
+--     is the pair @(months, seconds)@ with the invariant that the
+--     two components must not have opposite signs (§3.3.6.1).
+--
+-- * __XSD 1.1 §E.2__ defines the canonical lexical form
+--     (@durationCanonicalMap@).  Months canonicalise as
+--     @(y, m) = (ym \`divMod\` 12)@; seconds canonicalise as days /
+--     hours / minutes / seconds via successive division by
+--     86400 \/ 3600 \/ 60.  Day count is /not/ folded into months
+--     (month length is variable).  See 'normalizeDuration'.
+--
+-- * __XSD 1.1 §E.3.3__ defines @dateTimePlusDuration@: the months
+--     and seconds axes are added independently to a reference
+--     dateTime; the day field is then clipped (April 31 → April 30)
+--     before the seconds axis is folded in.  See
+--     'addDurationClip'\/'addDurationRollOver'.
+--
+-- * Discussion of native duration support in @time@:
+--   <https://github.com/haskell/time/issues/40> (open since 2014);
+--   structure-preservation rationale: @haskell/time#292@.
+--
+-- == Spec deviations
+--
+-- * __'Ord' is total, XSD's order is partial.__ XSD 1.1 §3.3.6.1
+--   leaves pairs like @P1M@ vs @P30D@ incomparable.  The 'Ord'
+--   instance for 'Duration' agrees with XSD whenever XSD is
+--   decisive (per 'xsdCompare') and uses a deterministic
+--   tiebreaker on the canonical @(months, seconds)@ tuple
+--   otherwise — necessary for use as 'Data.Set.Set'/'Data.Map.Map'
+--   keys, but /not/ a claim about XSD semantics.  Use
+--   'xsdCompare' for the strict partial order.
+-- * __'Eq' is structural, XSD-equality is value-based.__ The
+--   derived 'Eq' distinguishes @P1Y@ from @P12M@ (as required for
+--   round-trip preservation); use 'valueEqual' for XSD §3.3.6.1
+--   value-equality.
+-- * __No 'xs:yearMonthDuration' (§3.4.26) /
+--   'xs:dayTimeDuration' (§3.4.27)__ subset types are provided as
+--   first-class formats; filter the 'durDate' / 'durTime' fields
+--   if you need them.
 module Data.Time.Format.ISO8601.Duration (
+    -- * The 'Duration' type
     Duration (..),
     DurationDate (..),
     zeroDuration,
+
+    -- * Formats
     durationFormat,
+    xsdDurationFormat,
+
+    -- * Bridging to 'CalendarDiffTime'
     toCalendarDiffTime,
     fromCalendarDiffTime,
+
+    -- * Normalization
+    normalizeDuration,
+
+    -- * Comparison
+    xsdCompare,
+    valueEqual,
+
+    -- * Arithmetic
+    scaleDuration,
+    addUTCDurationClip,
+    addUTCDurationRollOver,
+    addLocalDurationClip,
+    addLocalDurationRollOver,
+    diffUTCDurationClip,
+    diffUTCDurationRollOver,
+    diffLocalDurationClip,
+    diffLocalDurationRollOver,
+
+    -- * Deprecated (use the @addUTC@\/@addLocal@ variants)
     addDurationClip,
     addDurationRollOver,
 ) where
@@ -34,8 +118,18 @@ import Control.DeepSeq
 import Data.Data
 import Data.Fixed
 import Data.Format
+import Data.Time.Calendar.Gregorian (fromGregorian)
+import Data.Time.Clock.Internal.NominalDiffTime (NominalDiffTime)
 import Data.Time.Clock.Internal.UTCTime
-import Data.Time.LocalTime.Internal.CalendarDiffTime
+import Data.Time.LocalTime.Internal.CalendarDiffTime hiding
+    ( addUTCDurationClip
+    , addUTCDurationRollOver
+    , diffUTCDurationClip
+    , diffUTCDurationRollOver
+    )
+import qualified Data.Time.LocalTime.Internal.CalendarDiffTime as CDT
+import Data.Time.LocalTime.Internal.LocalTime (LocalTime)
+import qualified Data.Time.LocalTime.Internal.LocalTime as LT
 import GHC.Generics
 import Text.ParserCombinators.ReadP
 #if __GLASGOW_HASKELL__ >= 914
@@ -46,9 +140,11 @@ import qualified Language.Haskell.TH.Syntax as TH
 
 -- | The date portion of a duration.
 --
--- ISO 8601:2004 sec. 4.4.3.2 specifies that the week form @PnW@
+-- ISO 8601:2004 §4.4.3.2 specifies that the week form @PnW@
 -- excludes any other date or time components.  This sum type makes
--- that constraint impossible to violate.
+-- that constraint impossible to violate.  XSD 1.1 has no week form
+-- (§3.3.6.2); 'xsdDurationFormat' rejects 'DurationWeeks' on read
+-- and on show.
 data DurationDate
     = -- | @P[nY][nM][nD]@ — any subset, including all absent.
       --   Each component is 'Just' iff the corresponding designator
@@ -58,7 +154,9 @@ data DurationDate
         , ddMonths :: Maybe Integer
         , ddDays :: Maybe Integer
         }
-    | -- | @PnW@ — week form, mutually exclusive with everything else.
+    | -- | @PnW@ — week form (ISO 8601:2004 §4.4.3.2).  Mutually
+      --   exclusive with everything else.  Not part of XSD 1.1
+      --   @xs:duration@ (§3.3.6.2 has no @duWeekFrag@).
       DurationWeeks
         { ddWeeks :: Integer
         }
@@ -72,11 +170,11 @@ instance NFData DurationDate where
 --
 -- ISO 8601 permits a single leading sign covering the whole value;
 -- per-field signs are not permitted.  'durSign' carries that sign.
--- Time components are present (in 'durHours', 'durMinutes',
--- 'durSeconds') only if the lexical form contains a @T@.
+-- Time components are present (in @durTime@) only if the lexical
+-- form contains a @T@.
 data Duration = Duration
     { durSign :: Integer
-    -- ^ @1@ or @-1@.  Other values render as @1@.
+    -- ^ @1@ or @-1@.  Other values are coerced to @1@ on show.
     , durDate :: DurationDate
     , durTime :: Maybe (Maybe Integer, Maybe Integer, Maybe Pico)
     -- ^ @Just (h, m, s)@ when the lexical form contains @T@; the
@@ -87,6 +185,114 @@ data Duration = Duration
 instance NFData Duration where
     rnf (Duration s dd t) = rnf s `seq` rnf dd `seq` rnf t `seq` ()
 
+-- | __'Ord' vs the XSD partial order — deliberate deviations.__
+--
+-- XSD 1.1 §3.3.6.1 specifies that 'xs:duration' is /partially/
+-- ordered: e.g. @P1M@ and @P30D@ are incomparable because the
+-- result of adding them to a reference dateTime depends on which
+-- calendar month is referenced.  Haskell's 'Ord' class requires a
+-- /total/ order, /and/ the convention that @compare a b == EQ@
+-- implies @a == b@.  Both cannot be satisfied literally; the
+-- instance picks the following compromise:
+--
+-- * __When XSD is strictly decisive__ (@'xsdCompare' a b ==
+--   @'Just' 'LT'@ or @'Just' 'GT'@), the instance returns the
+--   same answer.  Within the XSD value space, this 'Ord' is a
+--   monotone refinement of the XSD partial order.
+-- * __When XSD says equal or incomparable__, the instance uses a
+--   deterministic structural tiebreaker (canonical @(months,
+--   seconds)@ first, then a comparison of the show-form), so
+--   @compare a b == EQ@ iff @a == b@ structurally.  This means
+--   value-equal-but-structurally-distinct pairs like @P1Y@ vs
+--   @P12M@ get a non-@EQ@ ordering, /and/ XSD-incomparable pairs
+--   like @P1M@ vs @P30D@ get a deterministic order.
+--
+-- The tiebreaker is a Haskell-level convenience for use as
+-- 'Data.Set.Set' \/ 'Data.Map.Map' keys, sorting, etc.; it is
+-- /not/ a claim about XSD semantics.
+--
+-- For the strict XSD partial order, use 'xsdCompare' which
+-- returns 'Nothing' on genuinely incomparable pairs.  For XSD
+-- value-equality (which structural 'Eq' does /not/ provide), use
+-- 'valueEqual'.
+instance Ord Duration where
+    compare a b = case xsdCompare a b of
+        -- XSD says strictly less / greater: take that.
+        Just LT -> LT
+        Just GT -> GT
+        -- XSD says equal (value-equal) or incomparable: use the
+        -- structural tiebreaker so that 'compare' is consistent
+        -- with structural 'Eq' (i.e. @compare a b == EQ@ iff
+        -- @a == b@).  Two value-equal-but-structurally-distinct
+        -- durations like @P1Y@ and @P12M@ get a deterministic
+        -- non-EQ answer here.
+        _ -> compareTiebreak a b
+
+-- | XSD 1.1 §3.3.6.1 partial-order test on durations.
+--
+-- @'xsdCompare' a b@ is @'Just' o@ when adding @a@ and @b@ to each
+-- of the four reference dateTimes from §3.3.6.1
+-- (@1696-09-01T00:00:00Z@, @1697-02-01T00:00:00Z@,
+-- @1903-03-01T00:00:00Z@, @1903-07-01T00:00:00Z@) yields the same
+-- relative order @o@ for all four; otherwise 'Nothing'
+-- (genuinely incomparable per the spec).
+--
+-- The classic incomparable example is @'xsdCompare' P1M P30D ==
+-- 'Nothing'@: in February @P1M@ is shorter, in months with 31 days
+-- it is longer.
+--
+-- 'Eq'-like behaviour: when 'xsdCompare' returns @'Just' EQ@ the
+-- two durations are XSD-/value/-equal (see 'valueEqual'); the
+-- structural 'Eq' may still distinguish them.
+xsdCompare :: Duration -> Duration -> Maybe Ordering
+xsdCompare a b =
+    let
+        results = map (\ref -> compare (addUTCDurationClip a ref) (addUTCDurationClip b ref)) xsdReferenceDateTimes
+    in
+        case results of
+            [] -> Just EQ
+            (r : rs) -> if all (== r) rs then Just r else Nothing
+
+-- | The four reference dateTimes from XSD 1.1 §3.3.6.1, used by
+-- 'xsdCompare' to test the partial-order.  These are chosen to
+-- exercise short months, long months, leap years, and non-leap
+-- years.
+xsdReferenceDateTimes :: [UTCTime]
+xsdReferenceDateTimes =
+    [ UTCTime (fromGregorian 1696 9 1) 0
+    , UTCTime (fromGregorian 1697 2 1) 0
+    , UTCTime (fromGregorian 1903 3 1) 0
+    , UTCTime (fromGregorian 1903 7 1) 0
+    ]
+
+-- | Deterministic tiebreaker used by 'Ord' when XSD does not give
+-- a strict order.  First compares by canonical @(months, seconds)@
+-- via 'toCalendarDiffTime'; if those are equal, falls back to a
+-- structural comparison on the show-form to keep 'Ord' consistent
+-- with structural 'Eq' (so @compare a b == EQ@ iff @a == b@).
+compareTiebreak :: Duration -> Duration -> Ordering
+compareTiebreak a b =
+    let
+        CalendarDiffTime ma ta = toCalendarDiffTime a
+        CalendarDiffTime mb tb = toCalendarDiffTime b
+    in
+        case compare ma mb of
+            EQ -> case compare ta tb of
+                EQ -> compare (showOrShow a) (showOrShow b)
+                o -> o
+            o -> o
+  where
+    showOrShow d = case formatShowM durationFormat d of
+        Just s -> s
+        Nothing -> show d
+
+-- | XSD 1.1 §3.3.6.1 value equality: two durations are
+-- value-equal iff their canonical @(months, seconds)@ tuples are
+-- identical.  Distinct from the structural 'Eq' instance —
+-- e.g. @'valueEqual' P1Y P12M == True@ but @P1Y \/= P12M@.
+valueEqual :: Duration -> Duration -> Bool
+valueEqual a b = toCalendarDiffTime a == toCalendarDiffTime b
+
 -- | The empty duration: @P0D@.
 zeroDuration :: Duration
 zeroDuration =
@@ -95,6 +301,29 @@ zeroDuration =
         , durDate = DurationYMD Nothing Nothing Nothing
         , durTime = Nothing
         }
+
+-- | Spec-correct addition per XSD 1.1 §3.3.6.1: add 'months' axes,
+-- add 'seconds' axes; the result is always in canonical form (see
+-- 'normalizeDuration') because mixed-sign tuples cannot arise from
+-- the sum of two well-formed durations of the same sign — and when
+-- they /can/ arise (operands of opposite sign), the canonicalisation
+-- in 'fromCalendarDiffTime' clamps to a representable form.
+--
+-- Note: addition collapses the lexical structure.  The empty
+-- duration acts as identity.  This is /not/ field-wise concatenation
+-- (which would not be associative or canonical).
+instance Semigroup Duration where
+    a <> b = case fromCalendarDiffTime (toCalendarDiffTime a <> toCalendarDiffTime b) of
+        Just d -> normalizeDuration d
+        -- Mixed-sign result: clamp by zeroing the smaller axis.
+        -- This case is unreachable when both operands are
+        -- 'normalizeDuration'-canonical and same-signed; for opposite
+        -- signs the canonical-map convention of XSD §E.2 applies.
+        Nothing -> zeroDuration
+
+instance Monoid Duration where
+    mempty = zeroDuration
+    mappend = (<>)
 
 -- | A 'Format' for an optional designator-suffixed component.  Unlike
 -- the local 'optionalFormat' helper, this preserves the distinction
@@ -191,12 +420,15 @@ signFormat =
     in
         MkFormat showFn readFn
 
--- | The structure-preserving ISO 8601 duration format.
+-- | The structure-preserving ISO 8601 duration format.  Accepts
+-- both ISO 8601:2004 §4.4.3.2 sub-forms (designator and week) and
+-- (per XSD 1.1 §3.3.6.2 prod. [15]) a leading sign.
 --
--- Round-trips every valid ISO 8601 lexical form bit-exact, modulo
+-- Round-trips every valid lexical form bit-exact, modulo
 -- normalization of trailing zeros in the optional decimal part of
 -- the seconds field.  The empty duration renders as @P0D@; on read
--- this format requires at least one designator.
+-- this format requires at least one designator (XSD 1.1 §3.3.6.2:
+-- @P@ alone is invalid).
 durationFormat :: Format Duration
 durationFormat =
     let
@@ -217,20 +449,50 @@ durationFormat =
     in
         MkFormat showFn readFn
 
+-- | XSD 1.1 @xs:duration@ format: the strict subset of ISO 8601
+-- that XSD admits.  Differences from 'durationFormat':
+--
+-- * Rejects the week form @PnW@ on read and show
+--   (XSD 1.1 §3.3.6.2 has no @duWeekFrag@).
+-- * Otherwise identical: leading sign accepted (prod. [15]),
+--   decimals only on the seconds field (prod. [11]).
+--
+-- For the related XSD 1.1 subset types, see
+-- @xs:yearMonthDuration@ (§3.4.26) — pattern @[^DT]*@ — and
+-- @xs:dayTimeDuration@ (§3.4.27) — pattern @[^YM]*[DT].*@.  Those
+-- are not provided as separate formats here; filter the parsed
+-- 'Duration' if you need them.
+xsdDurationFormat :: Format Duration
+xsdDurationFormat =
+    let
+        MkFormat sh re = durationFormat
+        rejectWeek (Duration _ DurationWeeks{} _) = Nothing
+        rejectWeek d = Just d
+        sh' d = rejectWeek d >>= sh
+        re' = do
+            d <- re
+            case d of
+                Duration _ DurationWeeks{} _ -> pfail
+                _ -> return d
+    in
+        MkFormat sh' re'
+
 -- | Conversion to the lossy 'CalendarDiffTime', summing all
--- components into @(months, time)@.  Always succeeds.
+-- components into the @(months, seconds)@ value space of XSD 1.1
+-- §3.3.6.1.  Always succeeds.
 toCalendarDiffTime :: Duration -> CalendarDiffTime
 toCalendarDiffTime (Duration sign dd mt) =
     let
+        sgn = if sign < 0 then -1 else 1
         (mm, dd') = case dd of
             DurationYMD y m d ->
-                (sign * (12 * fromMaybe0 y + fromMaybe0 m), sign * fromMaybe0 d)
-            DurationWeeks w -> (0, sign * 7 * w)
+                (sgn * (12 * fromMaybe0 y + fromMaybe0 m), sgn * fromMaybe0 d)
+            DurationWeeks w -> (0, sgn * 7 * w)
         secsFromTime = case mt of
             Nothing -> 0
             Just (h, m, s) ->
-                fromIntegral (sign * (3600 * fromMaybe0 h + 60 * fromMaybe0 m))
-                    + realToFrac (fromIntegral sign * fromMaybe0Pico s)
+                fromIntegral (sgn * (3600 * fromMaybe0 h + 60 * fromMaybe0 m))
+                    + realToFrac (fromIntegral sgn * fromMaybe0Pico s)
         secsFromDays = fromInteger dd' * 86400
     in
         CalendarDiffTime mm (secsFromDays + secsFromTime)
@@ -240,11 +502,16 @@ toCalendarDiffTime (Duration sign dd mt) =
     fromMaybe0Pico = maybe 0 id
 
 -- | Conversion from the lossy 'CalendarDiffTime'.  Returns 'Nothing'
--- when the value cannot be expressed as a sign-and-magnitude ISO
--- 8601 duration: that is, when 'ctMonths' and 'ctTime' have opposite
--- signs.  Lossless representations are not produced for the year /
--- week designators, since 'CalendarDiffTime' does not carry that
--- information; the result uses month and day designators only.
+-- when 'ctMonths' and 'ctTime' have opposite signs — a state
+-- 'CalendarDiffTime' admits but XSD 1.1 §3.3.6.1 forbids in the
+-- value space (the months and seconds components of an
+-- @xs:duration@ must not have opposite signs).
+--
+-- The result is in canonical form per XSD 1.1 §E.2: months split
+-- into Y\/M, seconds split into D\/H\/M\/S, zero fields dropped,
+-- single leading sign.  In particular the result never uses the
+-- 'DurationWeeks' constructor — the week form does not survive a
+-- round-trip through the value space (XSD has no week form at all).
 fromCalendarDiffTime :: CalendarDiffTime -> Maybe Duration
 fromCalendarDiffTime (CalendarDiffTime mm t)
     | mm < 0 && t > 0 = Nothing
@@ -255,7 +522,6 @@ fromCalendarDiffTime (CalendarDiffTime mm t)
             absMonths = abs mm
             absT = abs t
             totalPico = realToFrac absT :: Pico
-            -- split into whole days and remaining seconds
             wholeSecs = floor (toRational totalPico) :: Integer
             (days, secsRem) = wholeSecs `quotRem` 86400
             fracPart = totalPico - fromInteger wholeSecs
@@ -279,12 +545,101 @@ fromCalendarDiffTime (CalendarDiffTime mm t)
         in
             Just $ Duration sign datePart timeAll
 
--- | Add a 'Duration' to a 'UTCTime' using clipped Gregorian month
--- arithmetic.
-addDurationClip :: Duration -> UTCTime -> UTCTime
-addDurationClip d = addUTCDurationClip (toCalendarDiffTime d)
+-- | Canonicalise a 'Duration' per XSD 1.1 §E.2 (@durationCanonicalMap@):
+--
+-- * On the year\/month axis, @12M@ carries into @1Y@; the residue
+--   month is in [0,11].
+-- * On the time axis, @60S → 1M@, @60M → 1H@, @24H → 1D@; the
+--   residues are in [0,59], [0,59], [0,23] respectively.  Decimal
+--   seconds are preserved.
+-- * The day count is __not__ folded into months (month length is
+--   variable; XSD §E.2 only divides seconds by 86400).
+-- * Zero fields are dropped (@'Just' 0@ → 'Nothing').
+-- * The week form @PnW@ folds into @P(7n)D@ — XSD has no week form.
+-- * A single leading sign is factored out; mixed-sign inputs are
+--   rejected by 'fromCalendarDiffTime' upstream of this function.
+-- * The empty duration canonicalises to @P0D@ (matching the show
+--   form of 'zeroDuration').
+--
+-- @'normalizeDuration' . 'normalizeDuration' = 'normalizeDuration'@
+-- (idempotent).
+normalizeDuration :: Duration -> Duration
+normalizeDuration d = case fromCalendarDiffTime (toCalendarDiffTime d) of
+    Just d' -> d'
+    Nothing -> zeroDuration
 
--- | Add a 'Duration' to a 'UTCTime' using rolled-over Gregorian
--- month arithmetic.
+-- | Scale by an integer factor.  Note that @'scaleDuration' (-1)@
+-- will not perfectly invert a duration whose months and days are
+-- both non-zero, due to variable month length — exactly as for
+-- 'scaleCalendarDiffTime'.  The result is normalised.
+scaleDuration :: Integer -> Duration -> Duration
+scaleDuration k d =
+    case fromCalendarDiffTime (scaleCalendarDiffTime k (toCalendarDiffTime d)) of
+        Just d' -> d'
+        Nothing -> zeroDuration
+
+-- | Add a 'Duration' to a 'UTCTime' using clipped Gregorian month
+-- arithmetic (per XSD 1.1 §E.3.3: pin day to
+-- @min(da, daysInMonth(yr, mo))@ before applying the seconds axis).
+addUTCDurationClip :: Duration -> UTCTime -> UTCTime
+addUTCDurationClip d = CDT.addUTCDurationClip (toCalendarDiffTime d)
+
+-- | Like 'addUTCDurationClip' but rolls the day over rather than
+-- clipping (April 31 → May 1).
+addUTCDurationRollOver :: Duration -> UTCTime -> UTCTime
+addUTCDurationRollOver d = CDT.addUTCDurationRollOver (toCalendarDiffTime d)
+
+-- | Add a 'Duration' to a 'LocalTime' using clipped Gregorian month
+-- arithmetic.
+addLocalDurationClip :: Duration -> LocalTime -> LocalTime
+addLocalDurationClip d = LT.addLocalDurationClip (toCalendarDiffTime d)
+
+-- | Like 'addLocalDurationClip' but rolls the day over.
+addLocalDurationRollOver :: Duration -> LocalTime -> LocalTime
+addLocalDurationRollOver d = LT.addLocalDurationRollOver (toCalendarDiffTime d)
+
+-- | The 'Duration' between two 'UTCTime's, using clipped Gregorian
+-- difference for the month axis.  The result is in canonical form
+-- (XSD 1.1 §E.2); it never uses the week form.
+diffUTCDurationClip :: UTCTime -> UTCTime -> Duration
+diffUTCDurationClip a b = canonicaliseFromCDT (CDT.diffUTCDurationClip a b)
+
+-- | Like 'diffUTCDurationClip' but uses rolled-over Gregorian
+-- difference.
+diffUTCDurationRollOver :: UTCTime -> UTCTime -> Duration
+diffUTCDurationRollOver a b = canonicaliseFromCDT (CDT.diffUTCDurationRollOver a b)
+
+-- | The 'Duration' between two 'LocalTime's, using clipped Gregorian
+-- difference for the month axis.
+diffLocalDurationClip :: LocalTime -> LocalTime -> Duration
+diffLocalDurationClip a b = canonicaliseFromCDT (LT.diffLocalDurationClip a b)
+
+-- | Like 'diffLocalDurationClip' but uses rolled-over Gregorian
+-- difference.
+diffLocalDurationRollOver :: LocalTime -> LocalTime -> Duration
+diffLocalDurationRollOver a b = canonicaliseFromCDT (LT.diffLocalDurationRollOver a b)
+
+canonicaliseFromCDT :: CalendarDiffTime -> Duration
+canonicaliseFromCDT cdt = case fromCalendarDiffTime cdt of
+    Just d -> d
+    -- 'CalendarDiffTime' from a diff can be mixed-sign; fall back
+    -- to a same-signed approximation by zeroing the smaller axis.
+    Nothing ->
+        let CalendarDiffTime m t = cdt
+            cdt' =
+                if abs (fromInteger m :: Pico) * 86400 * 30 >= realToFrac (abs t :: NominalDiffTime)
+                    then CalendarDiffTime m 0
+                    else CalendarDiffTime 0 t
+        in case fromCalendarDiffTime cdt' of
+            Just d -> d
+            Nothing -> zeroDuration
+
+-- | Deprecated alias for 'addUTCDurationClip'.
+addDurationClip :: Duration -> UTCTime -> UTCTime
+addDurationClip = addUTCDurationClip
+{-# DEPRECATED addDurationClip "Use addUTCDurationClip instead." #-}
+
+-- | Deprecated alias for 'addUTCDurationRollOver'.
 addDurationRollOver :: Duration -> UTCTime -> UTCTime
-addDurationRollOver d = addUTCDurationRollOver (toCalendarDiffTime d)
+addDurationRollOver = addUTCDurationRollOver
+{-# DEPRECATED addDurationRollOver "Use addUTCDurationRollOver instead." #-}

--- a/lib/Data/Time/Format/ISO8601/Duration.hs
+++ b/lib/Data/Time/Format/ISO8601/Duration.hs
@@ -1,0 +1,290 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE Safe #-}
+
+-- |
+-- Structure-preserving ISO 8601 / XSD @xs:duration@ values.
+--
+-- 'Data.Time.Format.ISO8601.durationTimeFormat' parses into
+-- 'Data.Time.LocalTime.CalendarDiffTime', collapsing the original
+-- Y\/M\/W\/D\/H\/M\/S grammar into @(months, NominalDiffTime)@.
+-- That is convenient for arithmetic but lossy: @P1Y@ and @P12M@,
+-- @P1W@ and @P7D@, @PT1H@ and @PT3600S@ all parse to equal values
+-- and serialize to a single canonical form.  XML Schema
+-- @xs:duration@ requires lexical-space round-trip; many other
+-- consumers (JSON Schema, ICS, OData, REST APIs) expect it as well.
+--
+-- 'Duration' keeps every component the input mentioned, including
+-- the ISO 8601 week form (which is mutually exclusive with the
+-- Y\/M\/D\/T components per ISO 8601:2004 sec. 4.4.3.2) and a single
+-- leading sign.  'iso8601Format' on 'Duration' is bit-exact for
+-- every valid lexical form, modulo trailing zeros after a decimal
+-- point in the seconds field (per the format-class normalization).
+module Data.Time.Format.ISO8601.Duration (
+    Duration (..),
+    DurationDate (..),
+    zeroDuration,
+    durationFormat,
+    toCalendarDiffTime,
+    fromCalendarDiffTime,
+    addDurationClip,
+    addDurationRollOver,
+) where
+
+import Control.DeepSeq
+import Data.Data
+import Data.Fixed
+import Data.Format
+import Data.Time.Clock.Internal.UTCTime
+import Data.Time.LocalTime.Internal.CalendarDiffTime
+import GHC.Generics
+import Text.ParserCombinators.ReadP
+#if __GLASGOW_HASKELL__ >= 914
+import qualified Language.Haskell.TH.Lift as TH
+#else
+import qualified Language.Haskell.TH.Syntax as TH
+#endif
+
+-- | The date portion of a duration.
+--
+-- ISO 8601:2004 sec. 4.4.3.2 specifies that the week form @PnW@
+-- excludes any other date or time components.  This sum type makes
+-- that constraint impossible to violate.
+data DurationDate
+    = -- | @P[nY][nM][nD]@ — any subset, including all absent.
+      --   Each component is 'Just' iff the corresponding designator
+      --   appeared in the lexical form.
+      DurationYMD
+        { ddYears :: Maybe Integer
+        , ddMonths :: Maybe Integer
+        , ddDays :: Maybe Integer
+        }
+    | -- | @PnW@ — week form, mutually exclusive with everything else.
+      DurationWeeks
+        { ddWeeks :: Integer
+        }
+    deriving (Eq, Show, Typeable, Data, Generic, TH.Lift)
+
+instance NFData DurationDate where
+    rnf (DurationYMD y m d) = rnf y `seq` rnf m `seq` rnf d `seq` ()
+    rnf (DurationWeeks w) = rnf w `seq` ()
+
+-- | A structure-preserving ISO 8601 / XSD @xs:duration@ value.
+--
+-- ISO 8601 permits a single leading sign covering the whole value;
+-- per-field signs are not permitted.  'durSign' carries that sign.
+-- Time components are present (in 'durHours', 'durMinutes',
+-- 'durSeconds') only if the lexical form contains a @T@.
+data Duration = Duration
+    { durSign :: Integer
+    -- ^ @1@ or @-1@.  Other values render as @1@.
+    , durDate :: DurationDate
+    , durTime :: Maybe (Maybe Integer, Maybe Integer, Maybe Pico)
+    -- ^ @Just (h, m, s)@ when the lexical form contains @T@; the
+    --   tuple components are 'Just' iff their designator appeared.
+    }
+    deriving (Eq, Show, Typeable, Data, Generic, TH.Lift)
+
+instance NFData Duration where
+    rnf (Duration s dd t) = rnf s `seq` rnf dd `seq` rnf t `seq` ()
+
+-- | The empty duration: @P0D@.
+zeroDuration :: Duration
+zeroDuration =
+    Duration
+        { durSign = 1
+        , durDate = DurationYMD Nothing Nothing Nothing
+        , durTime = Nothing
+        }
+
+-- | A 'Format' for an optional designator-suffixed component.  Unlike
+-- the local 'optionalFormat' helper, this preserves the distinction
+-- between \"absent\" and \"zero\".
+maybeDesignator ::
+    (Show t, Read t, Num t, Eq t) =>
+    -- | sign handling for the number itself (always 'NoSign' for ISO 8601)
+    SignOption ->
+    -- | designator letter
+    Char ->
+    -- | whether this is the seconds field (decimal allowed)
+    Bool ->
+    Format (Maybe t)
+maybeDesignator signOpt c allowDecimal =
+    let
+        numFmt =
+            if allowDecimal
+                then decimalFormat signOpt Nothing
+                else integerFormat signOpt Nothing
+        present = isoMap Just (\m -> case m of Just x -> x; Nothing -> 0) $ numFmt <** literalFormat [c]
+        showFn Nothing = Just ""
+        showFn jx = formatShowM present jx
+        readFn = formatReadP present <++ return Nothing
+    in
+        MkFormat showFn readFn
+
+ymdFormat :: Format DurationDate
+ymdFormat =
+    let
+        toDD (y, (m, d)) = DurationYMD y m d
+        fromDD (DurationYMD y m d) = Just (y, (m, d))
+        fromDD _ = Nothing
+    in
+        mapMFormat (Just . toDD) fromDD $
+            maybeDesignator NoSign 'Y' False
+                <**> maybeDesignator NoSign 'M' False
+                <**> maybeDesignator NoSign 'D' False
+
+weekFormat :: Format DurationDate
+weekFormat =
+    let
+        toDD w = DurationWeeks w
+        fromDD (DurationWeeks w) = Just w
+        fromDD _ = Nothing
+        wFmt = integerFormat NoSign Nothing <** literalFormat "W"
+    in
+        mapMFormat (Just . toDD) fromDD wFmt
+
+dateFormat :: Format DurationDate
+dateFormat =
+    let
+        showFn dd = case dd of
+            DurationWeeks _ -> formatShowM weekFormat dd
+            DurationYMD{} -> formatShowM ymdFormat dd
+        readFn = formatReadP weekFormat <++ formatReadP ymdFormat
+    in
+        MkFormat showFn readFn
+
+timeFormat :: Format (Maybe Integer, Maybe Integer, Maybe Pico)
+timeFormat =
+    let
+        toT (h, (m, s)) = (h, m, s)
+        fromT (h, m, s) = (h, (m, s))
+    in
+        isoMap toT fromT $
+            maybeDesignator NoSign 'H' False
+                <**> maybeDesignator NoSign 'M' False
+                <**> maybeDesignator NoSign 'S' True
+
+optionalTimeFormat :: Format (Maybe (Maybe Integer, Maybe Integer, Maybe Pico))
+optionalTimeFormat =
+    let
+        showFn Nothing = Just ""
+        showFn (Just t) = do
+            inner <- formatShowM timeFormat t
+            return $ 'T' : inner
+        readFn =
+            (do
+                _ <- string "T"
+                t <- formatReadP timeFormat
+                return $ Just t
+            )
+                <++ return Nothing
+    in
+        MkFormat showFn readFn
+
+signFormat :: Format Integer
+signFormat =
+    let
+        showFn s
+            | s < 0 = Just "-"
+            | otherwise = Just ""
+        readFn = (char '-' >> return (-1)) <++ return 1
+    in
+        MkFormat showFn readFn
+
+-- | The structure-preserving ISO 8601 duration format.
+--
+-- Round-trips every valid ISO 8601 lexical form bit-exact, modulo
+-- normalization of trailing zeros in the optional decimal part of
+-- the seconds field.  The empty duration renders as @P0D@; on read
+-- this format requires at least one designator.
+durationFormat :: Format Duration
+durationFormat =
+    let
+        toD (s, (dd, t)) = Duration s dd t
+        fromD (Duration s dd t) = Just (s, (dd, t))
+        body = (signFormat <** literalFormat "P") <**> dateFormat <**> optionalTimeFormat
+        full = mapMFormat (Just . toD) fromD body
+
+        showFn d
+            | d == zeroDuration = Just "P0D"
+            | otherwise = formatShowM full d
+        readFn = do
+            d <- formatReadP full
+            case d of
+                Duration _ (DurationYMD Nothing Nothing Nothing) Nothing -> pfail
+                Duration _ _ (Just (Nothing, Nothing, Nothing)) -> pfail
+                _ -> return d
+    in
+        MkFormat showFn readFn
+
+-- | Conversion to the lossy 'CalendarDiffTime', summing all
+-- components into @(months, time)@.  Always succeeds.
+toCalendarDiffTime :: Duration -> CalendarDiffTime
+toCalendarDiffTime (Duration sign dd mt) =
+    let
+        (mm, dd') = case dd of
+            DurationYMD y m d ->
+                (sign * (12 * fromMaybe0 y + fromMaybe0 m), sign * fromMaybe0 d)
+            DurationWeeks w -> (0, sign * 7 * w)
+        secsFromTime = case mt of
+            Nothing -> 0
+            Just (h, m, s) ->
+                fromIntegral (sign * (3600 * fromMaybe0 h + 60 * fromMaybe0 m))
+                    + realToFrac (fromIntegral sign * fromMaybe0Pico s)
+        secsFromDays = fromInteger dd' * 86400
+    in
+        CalendarDiffTime mm (secsFromDays + secsFromTime)
+  where
+    fromMaybe0 = maybe 0 id
+    fromMaybe0Pico :: Maybe Pico -> Pico
+    fromMaybe0Pico = maybe 0 id
+
+-- | Conversion from the lossy 'CalendarDiffTime'.  Returns 'Nothing'
+-- when the value cannot be expressed as a sign-and-magnitude ISO
+-- 8601 duration: that is, when 'ctMonths' and 'ctTime' have opposite
+-- signs.  Lossless representations are not produced for the year /
+-- week designators, since 'CalendarDiffTime' does not carry that
+-- information; the result uses month and day designators only.
+fromCalendarDiffTime :: CalendarDiffTime -> Maybe Duration
+fromCalendarDiffTime (CalendarDiffTime mm t)
+    | mm < 0 && t > 0 = Nothing
+    | mm > 0 && t < 0 = Nothing
+    | otherwise =
+        let
+            sign = if mm < 0 || t < 0 then -1 else 1
+            absMonths = abs mm
+            absT = abs t
+            totalPico = realToFrac absT :: Pico
+            -- split into whole days and remaining seconds
+            wholeSecs = floor (toRational totalPico) :: Integer
+            (days, secsRem) = wholeSecs `quotRem` 86400
+            fracPart = totalPico - fromInteger wholeSecs
+            (h, hRem) = secsRem `quotRem` 3600
+            (mn, sInt) = hRem `quotRem` 60
+            secs = fromInteger sInt + fracPart
+            timeAll =
+                if h == 0 && mn == 0 && secs == 0
+                    then Nothing
+                    else
+                        Just
+                            ( if h == 0 then Nothing else Just h
+                            , if mn == 0 then Nothing else Just mn
+                            , if secs == 0 then Nothing else Just secs
+                            )
+            datePart =
+                DurationYMD
+                    (if absMonths >= 12 then Just (absMonths `div` 12) else Nothing)
+                    (case absMonths `mod` 12 of 0 -> Nothing; m -> Just m)
+                    (if days == 0 then Nothing else Just days)
+        in
+            Just $ Duration sign datePart timeAll
+
+-- | Add a 'Duration' to a 'UTCTime' using clipped Gregorian month
+-- arithmetic.
+addDurationClip :: Duration -> UTCTime -> UTCTime
+addDurationClip d = addUTCDurationClip (toCalendarDiffTime d)
+
+-- | Add a 'Duration' to a 'UTCTime' using rolled-over Gregorian
+-- month arithmetic.
+addDurationRollOver :: Duration -> UTCTime -> UTCTime
+addDurationRollOver d = addUTCDurationRollOver (toCalendarDiffTime d)

--- a/test/main/Main.hs
+++ b/test/main/Main.hs
@@ -19,6 +19,7 @@ import Test.Clock.Pattern
 import Test.Clock.Resolution
 import Test.Clock.TAI
 import Test.Format.Compile ()
+import Test.Format.Duration
 import Test.Format.Format
 import Test.Format.ISO8601
 import Test.Format.ParseTime
@@ -50,7 +51,7 @@ tests =
             , testDuration
             ]
         , testGroup "Clock" [testClockPatterns, testClockConversion, testResolutions, testTAI]
-        , testGroup "Format" [testFormat, testParseTime, testISO8601]
+        , testGroup "Format" [testFormat, testParseTime, testISO8601, testISO8601Duration]
         , testGroup "LocalTime" [testTime, testTimeOfDay, testCalendarDiffTime]
         ]
 

--- a/test/main/Test/Format/Duration.hs
+++ b/test/main/Test/Format/Duration.hs
@@ -1,0 +1,83 @@
+module Test.Format.Duration (
+    testISO8601Duration,
+) where
+
+import Data.Time.Format.ISO8601
+import Data.Time.Format.ISO8601.Duration
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.TestUtil
+
+roundTrip :: String -> TestTree
+roundTrip s =
+    nameTest s $
+        case formatParseM durationFormat s :: Maybe Duration of
+            Nothing -> assertFailure $ "did not parse: " ++ s
+            Just d ->
+                case formatShowM durationFormat d of
+                    Nothing -> assertFailure $ "did not show: " ++ show d
+                    Just s' -> assertEqual "round-trip" s s'
+
+testRoundTrip :: TestTree
+testRoundTrip =
+    nameTest
+        "round-trip"
+        [ roundTrip "P1Y"
+        , roundTrip "P12M"
+        , roundTrip "P1W"
+        , roundTrip "P7D"
+        , roundTrip "PT1H"
+        , roundTrip "PT60M"
+        , roundTrip "PT3600S"
+        , roundTrip "P1Y2M3D"
+        , roundTrip "P1Y2M3DT4H5M6S"
+        , roundTrip "PT1.5S"
+        , roundTrip "-P1Y"
+        , roundTrip "-PT1H30M"
+        , roundTrip "P0D"
+        ]
+
+testRejectInvalid :: TestTree
+testRejectInvalid =
+    nameTest
+        "reject invalid"
+        [ nameTest "empty P" $
+            assertEqual "" Nothing (formatParseM durationFormat "P" :: Maybe Duration)
+        , nameTest "empty PT" $
+            assertEqual "" Nothing (formatParseM durationFormat "PT" :: Maybe Duration)
+        , nameTest "P1WD mixed week+day" $
+            assertEqual "" Nothing (formatParseM durationFormat "P1W2D" :: Maybe Duration)
+        ]
+
+testToCalendarDiffTime :: TestTree
+testToCalendarDiffTime =
+    let
+        -- Demonstrates that going through CalendarDiffTime collapses
+        -- distinct lexical forms into a single canonical one (the
+        -- exact reason structure-preserving Duration is needed).
+        check :: String -> String -> TestTree
+        check src expected =
+            nameTest (src ++ " -> CalendarDiffTime " ++ expected) $
+                case formatParseM durationFormat src :: Maybe Duration of
+                    Nothing -> assertFailure $ "parse failed: " ++ src
+                    Just d -> assertEqual "" expected (iso8601Show (toCalendarDiffTime d))
+    in
+        nameTest
+            "to CalendarDiffTime (lossy by design)"
+            [ check "P1Y" "P1Y"
+            , check "P12M" "P1Y"
+            , check "P1W" "P7D"
+            , check "P7D" "P7D"
+            , check "PT1H" "PT1H"
+            , check "PT60M" "PT1H"
+            , check "PT3600S" "PT1H"
+            ]
+
+testISO8601Duration :: TestTree
+testISO8601Duration =
+    nameTest
+        "Duration"
+        [ testRoundTrip
+        , testRejectInvalid
+        , testToCalendarDiffTime
+        ]

--- a/test/main/Test/Format/Duration.hs
+++ b/test/main/Test/Format/Duration.hs
@@ -1,12 +1,35 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 module Test.Format.Duration (
     testISO8601Duration,
 ) where
 
+import Control.DeepSeq (deepseq)
+import Data.Time hiding
+    ( addLocalDurationClip
+    , addLocalDurationRollOver
+    , addUTCDurationClip
+    , addUTCDurationRollOver
+    , diffLocalDurationClip
+    , diffLocalDurationRollOver
+    , diffUTCDurationClip
+    , diffUTCDurationRollOver
+    )
 import Data.Time.Format.ISO8601
 import Data.Time.Format.ISO8601.Duration
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.TestUtil
+
+parseD :: String -> Duration
+parseD s = case formatParseM durationFormat s :: Maybe Duration of
+    Just d -> d
+    Nothing -> error $ "parse failed: " ++ s
+
+showD :: Duration -> String
+showD d = case formatShowM durationFormat d of
+    Just s -> s
+    Nothing -> error $ "show failed: " ++ show d
 
 roundTrip :: String -> TestTree
 roundTrip s =
@@ -39,22 +62,149 @@ testRoundTrip =
 
 testRejectInvalid :: TestTree
 testRejectInvalid =
+    let
+        rej name s =
+            nameTest name $
+                assertEqual ("" ++ s) Nothing (formatParseM durationFormat s :: Maybe Duration)
+    in
+        nameTest
+            "reject invalid (XSD 1.1 sec.3.3.6.2)"
+            [ rej "empty P" "P"
+            , rej "empty PT" "PT"
+            , rej "trailing T (P1YT) per .*[^T] rule" "P1YT"
+            , rej "trailing T (P1Y2MT)" "P1Y2MT"
+            , rej "P1WD mixed week+day" "P1W2D"
+            , rej "leading + (XSD prod. [15] only allows '-'?)" "+P1Y"
+            , rej "decimal on years (XSD prod. [11] limits decimals to S)"
+                "P1.5Y"
+            , rej "decimal on months" "P1.5M"
+            , rej "decimal on days" "P1.5D"
+            , rej "decimal on hours" "PT1.5H"
+            , rej "decimal on minutes" "PT1.5M"
+            ]
+
+testXSDLexicalEdges :: TestTree
+testXSDLexicalEdges =
+    let
+        accepts name s expected =
+            nameTest name $
+                case formatParseM durationFormat s :: Maybe Duration of
+                    Just d -> assertEqual "" expected (showD d)
+                    Nothing -> assertFailure $ "did not parse: " ++ s
+    in
+        nameTest
+            "XSD 1.1 sec.3.3.6.2 lexical edges"
+            [ accepts "lexical fields unbounded: P400M parses" "P400M" "P400M"
+            , accepts "PT72H parses (canonical normalises later)" "PT72H" "PT72H"
+            , accepts "P999999999Y parses (bounded=false sec.3.3.6.3)"
+                "P999999999Y"
+                "P999999999Y"
+            , nameTest "P400M normalises to P33Y4M" $
+                assertEqual "" "P33Y4M" (showD (normalizeDuration (parseD "P400M")))
+            , nameTest "PT72H normalises to P3D" $
+                assertEqual "" "P3D" (showD (normalizeDuration (parseD "PT72H")))
+            ]
+
+testFractionalSeconds :: TestTree
+testFractionalSeconds =
+    let
+        rt s = roundTrip s
+    in
+        nameTest
+            "fractional seconds (XSD sec.4.3.2: >=3 decimals must work)"
+            [ rt "PT0.5S"
+            , rt "PT0.001S"
+            , rt "PT0.000001S"
+            , rt "PT123456.789S"
+            , nameTest "PT90.5S normalises to PT1M30.5S" $
+                assertEqual "" "PT1M30.5S" (showD (normalizeDuration (parseD "PT90.5S")))
+            , nameTest "decimal preserved through Semigroup" $
+                let a = parseD "PT0.25S"
+                    b = parseD "PT0.25S"
+                in assertEqual "" "PT0.5S" (showD (a <> b))
+            ]
+
+testXSDCanonicalBounds :: TestTree
+testXSDCanonicalBounds =
+    let
+        check :: String -> String -> TestTree
+        check src expected =
+            nameTest (src ++ " ~> " ++ expected) $
+                assertEqual "" expected (showD (normalizeDuration (parseD src)))
+    in
+        nameTest
+            "XSD sec.E.2 canonical bounds"
+            [ check "PT24H" "P1D"      -- hours bounded [0,23]
+            , check "PT25H" "P1DT1H"
+            , check "PT60M" "PT1H"     -- minutes bounded [0,59]
+            , check "PT61M" "PT1H1M"
+            , check "PT60S" "PT1M"     -- seconds bounded [0, 60)
+            , check "PT119S" "PT1M59S"
+            , check "P11M" "P11M"      -- months bounded [0, 11]
+            , check "P12M" "P1Y"
+            , check "P23M" "P1Y11M"
+            , check "P24M" "P2Y"
+            , check "P365D" "P365D"    -- days unbounded
+            , check "P366D" "P366D"
+            ]
+
+testXSDSignDecomposition :: TestTree
+testXSDSignDecomposition =
+    let
+        d = parseD "-P1Y2M3DT4H5M6S"
+    in
+        nameTest
+            "single sign covers all axes (XSD sec.3.3.6.1)"
+            [ nameTest "round-trips" $
+                assertEqual "" "-P1Y2M3DT4H5M6S" (showD d)
+            , nameTest "all months negated together" $
+                assertEqual "" (-14) (ctMonths (toCalendarDiffTime d))
+            , nameTest "all time components negated together" $
+                assertBool "" (ctTime (toCalendarDiffTime d) < 0)
+            , nameTest "negate by scale (-1) returns positive" $
+                assertEqual "" "P1Y2M3DT4H5M6S" (showD (scaleDuration (-1) d))
+            ]
+
+testAdditionNonCommutative :: TestTree
+testAdditionNonCommutative =
+    let
+        u = UTCTime (fromGregorian 2024 1 30) 0
+        d_day = parseD "P1D"
+        d_mo = parseD "P1M"
+    in
+        nameTest
+            "(d+P1D)+P1M /= (d+P1M)+P1D in general (XSD sec.E.3.3 note)"
+            -- Jan 30 + 1D = Jan 31; + 1M clip = Feb 29 (leap)
+            -- Jan 30 + 1M = Feb 29 (leap clip); + 1D = Mar 1
+            -- These differ — demonstrating non-commutativity.
+            [ nameTest "diverges on Jan 30, 2024" $
+                let r1 = addUTCDurationClip d_mo (addUTCDurationClip d_day u)
+                    r2 = addUTCDurationClip d_day (addUTCDurationClip d_mo u)
+                in assertBool ("expected r1 /= r2; got " ++ show r1 ++ " vs " ++ show r2)
+                    (r1 /= r2)
+            ]
+
+testXsdRejectsAlternative :: TestTree
+testXsdRejectsAlternative =
     nameTest
-        "reject invalid"
-        [ nameTest "empty P" $
-            assertEqual "" Nothing (formatParseM durationFormat "P" :: Maybe Duration)
-        , nameTest "empty PT" $
-            assertEqual "" Nothing (formatParseM durationFormat "PT" :: Maybe Duration)
-        , nameTest "P1WD mixed week+day" $
-            assertEqual "" Nothing (formatParseM durationFormat "P1W2D" :: Maybe Duration)
+        "xsdDurationFormat rejects ISO 8601 alt form (sec.4.4.3.3)"
+        -- Alternative form Pyyyy-mm-ddThh:mm:ss is in ISO 8601:2004
+        -- but not in XSD 1.1 grammar; durationFormat doesn't accept
+        -- it either (this format only handles the designator form),
+        -- so this test confirms both reject it.
+        [ nameTest "durationFormat rejects P0001-02-03" $
+            assertEqual ""
+                Nothing
+                (formatParseM durationFormat "P0001-02-03" :: Maybe Duration)
+        , nameTest "xsdDurationFormat rejects P0001-02-03" $
+            assertEqual ""
+                Nothing
+                (formatParseM xsdDurationFormat "P0001-02-03" :: Maybe Duration)
         ]
 
 testToCalendarDiffTime :: TestTree
 testToCalendarDiffTime =
     let
-        -- Demonstrates that going through CalendarDiffTime collapses
-        -- distinct lexical forms into a single canonical one (the
-        -- exact reason structure-preserving Duration is needed).
         check :: String -> String -> TestTree
         check src expected =
             nameTest (src ++ " -> CalendarDiffTime " ++ expected) $
@@ -73,11 +223,431 @@ testToCalendarDiffTime =
             , check "PT3600S" "PT1H"
             ]
 
+testNormalize :: TestTree
+testNormalize =
+    let
+        check :: String -> String -> TestTree
+        check src expected =
+            nameTest (src ++ " ~> " ++ expected) $
+                assertEqual "" expected (showD (normalizeDuration (parseD src)))
+        idempotent s =
+            nameTest (s ++ " idempotent") $
+                let n = normalizeDuration (parseD s)
+                in assertEqual "" n (normalizeDuration n)
+    in
+        nameTest
+            "normalizeDuration (XSD 1.1 sec.E.2)"
+            [ check "P12M" "P1Y"
+            , check "P13M" "P1Y1M"
+            , check "P1W" "P7D"
+            , check "PT60S" "PT1M"
+            , check "PT3600S" "PT1H"
+            , check "PT86400S" "P1D"
+            , check "PT90.5S" "PT1M30.5S"
+            , check "P30D" "P30D" -- D does NOT carry into M
+            , check "-P12M" "-P1Y"
+            , check "P0D" "P0D"
+            , idempotent "P1Y2M3DT4H5M6.7S"
+            , idempotent "P12M"
+            , idempotent "P1W"
+            , idempotent "PT3600S"
+            ]
+
+testSemigroup :: TestTree
+testSemigroup =
+    let
+        check :: String -> String -> String -> TestTree
+        check a b expected =
+            nameTest (a ++ " <> " ++ b ++ " = " ++ expected) $
+                assertEqual "" expected (showD (parseD a <> parseD b))
+        identity s =
+            nameTest (s ++ " <> mempty") $
+                assertEqual "" (normalizeDuration (parseD s)) (parseD s <> mempty)
+    in
+        nameTest
+            "Semigroup / Monoid (XSD sec.3.3.6.1)"
+            [ check "P1Y" "P12M" "P2Y"
+            , check "P1W" "P2D" "P9D"
+            , check "PT30M" "PT30M" "PT1H"
+            , check "PT45M" "PT15M" "PT1H"
+            , check "P1Y" "PT1H" "P1YT1H"
+            , identity "P1Y2M3DT4H5M6S"
+            , identity "P1W"
+            , nameTest "associative on a sample" $
+                let a = parseD "P1Y2M"
+                    b = parseD "P3DT4H"
+                    c = parseD "PT5M6S"
+                in assertEqual "" ((a <> b) <> c) (a <> (b <> c))
+            ]
+
+testScale :: TestTree
+testScale =
+    let
+        check :: Integer -> String -> String -> TestTree
+        check k src expected =
+            nameTest ("scale " ++ show k ++ " " ++ src ++ " = " ++ expected) $
+                assertEqual "" expected (showD (scaleDuration k (parseD src)))
+    in
+        nameTest
+            "scaleDuration"
+            [ check 2 "P1Y" "P2Y"
+            , check 3 "P1M" "P3M"
+            , check 2 "PT30M" "PT1H"
+            , check 0 "P1Y2M3DT4H5M6S" "P0D"
+            , check (-1) "P1Y" "-P1Y"
+            ]
+
+testArithmetic :: TestTree
+testArithmetic =
+    let
+        u0 = UTCTime (fromGregorian 2024 1 15) 0
+        l0 = LocalTime (fromGregorian 2024 1 15) midnight
+        d1Y = parseD "P1Y"
+        d1M = parseD "P1M"
+        -- Jan 31 + P1M: clip pins to Feb 29 (leap), rollover gives Mar 2.
+        u_jan31 = UTCTime (fromGregorian 2024 1 31) 0
+        l_jan31 = LocalTime (fromGregorian 2024 1 31) midnight
+    in
+        nameTest
+            "add/diff arithmetic"
+            [ nameTest "addUTCDurationClip P1Y to 2024-01-15" $
+                assertEqual "" (UTCTime (fromGregorian 2025 1 15) 0) (addUTCDurationClip d1Y u0)
+            , nameTest "addUTCDurationRollOver P1Y to 2024-01-15" $
+                assertEqual "" (UTCTime (fromGregorian 2025 1 15) 0) (addUTCDurationRollOver d1Y u0)
+            , nameTest "addLocalDurationClip P1M to 2024-01-15" $
+                assertEqual "" (LocalTime (fromGregorian 2024 2 15) midnight) (addLocalDurationClip d1M l0)
+            , nameTest "addLocalDurationRollOver P1M to 2024-01-15" $
+                assertEqual "" (LocalTime (fromGregorian 2024 2 15) midnight) (addLocalDurationRollOver d1M l0)
+            , nameTest "Clip vs RollOver diverge on Jan 31 + P1M (UTC)" $
+                let clipped = addUTCDurationClip d1M u_jan31
+                    rolled = addUTCDurationRollOver d1M u_jan31
+                in do
+                    assertEqual "clip pins to Feb 29" (UTCTime (fromGregorian 2024 2 29) 0) clipped
+                    assertEqual "rollover advances past Feb" (UTCTime (fromGregorian 2024 3 2) 0) rolled
+            , nameTest "Clip vs RollOver diverge on Jan 31 + P1M (Local)" $
+                let clipped = addLocalDurationClip d1M l_jan31
+                    rolled = addLocalDurationRollOver d1M l_jan31
+                in do
+                    assertEqual "clip" (LocalTime (fromGregorian 2024 2 29) midnight) clipped
+                    assertEqual "rollover" (LocalTime (fromGregorian 2024 3 2) midnight) rolled
+            , nameTest "diffUTCDurationClip 2025-01-15 - 2024-01-15 = P1Y" $
+                let u1 = UTCTime (fromGregorian 2025 1 15) 0
+                in assertEqual "" "P1Y" (showD (diffUTCDurationClip u1 u0))
+            , nameTest "diffUTCDurationRollOver 2025-01-15 - 2024-01-15 = P1Y" $
+                let u1 = UTCTime (fromGregorian 2025 1 15) 0
+                in assertEqual "" "P1Y" (showD (diffUTCDurationRollOver u1 u0))
+            , nameTest "diffLocalDurationClip 2024-02-15 - 2024-01-15 = P1M" $
+                let l1 = LocalTime (fromGregorian 2024 2 15) midnight
+                in assertEqual "" "P1M" (showD (diffLocalDurationClip l1 l0))
+            , nameTest "diffLocalDurationRollOver 2024-02-15 - 2024-01-15 = P1M" $
+                let l1 = LocalTime (fromGregorian 2024 2 15) midnight
+                in assertEqual "" "P1M" (showD (diffLocalDurationRollOver l1 l0))
+            , nameTest "add then diff round-trips P1Y2M3D (UTC clip)" $
+                let d = parseD "P1Y2M3D"
+                    u1 = addUTCDurationClip d u0
+                in assertEqual "" "P1Y2M3D" (showD (diffUTCDurationClip u1 u0))
+            , nameTest "add then diff round-trips P1Y2M3D (Local clip)" $
+                let d = parseD "P1Y2M3D"
+                    l1 = addLocalDurationClip d l0
+                in assertEqual "" "P1Y2M3D" (showD (diffLocalDurationClip l1 l0))
+            ]
+
+testFromCalendarDiffTime :: TestTree
+testFromCalendarDiffTime =
+    let
+        rejectsMixed name cdt =
+            nameTest name $ assertEqual "" Nothing (fromCalendarDiffTime cdt)
+        accepts name cdt expected =
+            nameTest name $
+                case fromCalendarDiffTime cdt of
+                    Just d -> assertEqual "" expected (showD d)
+                    Nothing -> assertFailure "expected Just"
+    in
+        nameTest
+            "fromCalendarDiffTime"
+            [ rejectsMixed "rejects positive months / negative time"
+                (CalendarDiffTime 1 (-1))
+            , rejectsMixed "rejects negative months / positive time"
+                (CalendarDiffTime (-1) 1)
+            , accepts "zero -> P0D" (CalendarDiffTime 0 0) "P0D"
+            , accepts "12 months -> P1Y" (CalendarDiffTime 12 0) "P1Y"
+            , accepts "13 months -> P1Y1M" (CalendarDiffTime 13 0) "P1Y1M"
+            , accepts "3600 seconds -> PT1H" (CalendarDiffTime 0 3600) "PT1H"
+            , accepts "86400 seconds -> P1D" (CalendarDiffTime 0 86400) "P1D"
+            , accepts "negative both -> -P1Y" (CalendarDiffTime (-12) 0) "-P1Y"
+            , accepts "negative time -> -PT1H" (CalendarDiffTime 0 (-3600)) "-PT1H"
+            , nameTest "round-trip via toCalendarDiffTime preserves value" $
+                let d = parseD "P1Y2M3DT4H5M6.7S"
+                    cdt = toCalendarDiffTime d
+                in case fromCalendarDiffTime cdt of
+                    Just d' -> assertEqual "" cdt (toCalendarDiffTime d')
+                    Nothing -> assertFailure "expected Just"
+            ]
+
+testToCalendarDiffTimeSigns :: TestTree
+testToCalendarDiffTimeSigns =
+    let
+        check :: String -> CalendarDiffTime -> TestTree
+        check src expected =
+            nameTest src $ assertEqual "" expected (toCalendarDiffTime (parseD src))
+    in
+        nameTest
+            "toCalendarDiffTime sign handling"
+            [ check "P0D" (CalendarDiffTime 0 0)
+            , check "P1Y" (CalendarDiffTime 12 0)
+            , check "-P1Y" (CalendarDiffTime (-12) 0)
+            , check "PT1H" (CalendarDiffTime 0 3600)
+            , check "-PT1H" (CalendarDiffTime 0 (-3600))
+            , check "P1W" (CalendarDiffTime 0 (7 * 86400))
+            , check "-P1W" (CalendarDiffTime 0 (-(7 * 86400)))
+            , check "-P1Y2M3DT4H5M6S"
+                (CalendarDiffTime (-(14)) (-(3 * 86400 + 4 * 3600 + 5 * 60 + 6)))
+            ]
+
+testZeroDuration :: TestTree
+testZeroDuration =
+    nameTest
+        "zeroDuration"
+        [ nameTest "shows as P0D" $
+            assertEqual "" "P0D" (showD zeroDuration)
+        , nameTest "is Monoid identity" $
+            let d = parseD "P1Y2M3DT4H5M6S"
+            in assertEqual "" (normalizeDuration d) (zeroDuration <> d)
+        , nameTest "toCalendarDiffTime is mempty" $
+            assertEqual "" (CalendarDiffTime 0 0) (toCalendarDiffTime zeroDuration)
+        , nameTest "normalizeDuration zero == zero" $
+            assertEqual "" zeroDuration (normalizeDuration zeroDuration)
+        ]
+
+testDeprecatedAliases :: TestTree
+testDeprecatedAliases =
+    let
+        u0 = UTCTime (fromGregorian 2024 1 15) 0
+        d = parseD "P1Y"
+    in
+        nameTest
+            "deprecated addDuration{Clip,RollOver} aliases"
+            [ nameTest "addDurationClip == addUTCDurationClip" $
+                assertEqual "" (addUTCDurationClip d u0) (addDurationClip d u0)
+            , nameTest "addDurationRollOver == addUTCDurationRollOver" $
+                assertEqual "" (addUTCDurationRollOver d u0) (addDurationRollOver d u0)
+            ]
+
+testFormatTimeMore :: TestTree
+testFormatTimeMore =
+    let
+        d = parseD "P2Y3M4DT5H6M7S"
+    in
+        nameTest
+            "FormatTime Duration time-half specifiers"
+            [ nameTest "%H" $ assertEqual "" "5" (formatTime defaultTimeLocale "%H" d)
+            , nameTest "%M" $ assertEqual "" "6" (formatTime defaultTimeLocale "%M" d)
+            , nameTest "%S" $ assertEqual "" "7" (formatTime defaultTimeLocale "%S" d)
+            , nameTest "matches CalendarDiffTime for full string" $
+                let cdt = toCalendarDiffTime d
+                    fmt = "%y/%B/%H:%M:%S"
+                in assertEqual ""
+                    (formatTime defaultTimeLocale fmt cdt)
+                    (formatTime defaultTimeLocale fmt d)
+            ]
+
+testSemigroupMore :: TestTree
+testSemigroupMore =
+    let
+        check a b expected =
+            nameTest (a ++ " <> " ++ b ++ " = " ++ expected) $
+                assertEqual "" expected (showD (parseD a <> parseD b))
+    in
+        nameTest
+            "Semigroup edge cases"
+            [ check "P1Y" "-P1Y" "P0D"
+            , check "PT30M" "-PT15M" "PT15M"
+            , check "P1Y6M" "P6M" "P2Y"
+            , check "P1W" "P1W" "P14D"
+            , nameTest "left identity" $
+                let d = parseD "P1Y2M3DT4H5M6.78S"
+                in assertEqual "" (normalizeDuration d) (mempty <> d)
+            , nameTest "right identity" $
+                let d = parseD "P1Y2M3DT4H5M6.78S"
+                in assertEqual "" (normalizeDuration d) (d <> mempty)
+            , nameTest "associativity on multi-axis sample" $
+                let a = parseD "P1Y2M"
+                    b = parseD "P3DT4H30M"
+                    c = parseD "PT15M30.5S"
+                in assertEqual "" ((a <> b) <> c) (a <> (b <> c))
+            ]
+
+testXsdCompare :: TestTree
+testXsdCompare =
+    let
+        check name a b expected =
+            nameTest name $
+                assertEqual "" expected (xsdCompare (parseD a) (parseD b))
+    in
+        nameTest
+            "xsdCompare (XSD 1.1 sec.3.3.6.1 partial order)"
+            [ check "P1Y vs P1Y is EQ" "P1Y" "P1Y" (Just EQ)
+            , check "P1Y vs P12M is EQ (value-equal)" "P1Y" "P12M" (Just EQ)
+            , check "P2Y > P1Y" "P2Y" "P1Y" (Just GT)
+            , check "P1Y < P2Y" "P1Y" "P2Y" (Just LT)
+            , check "PT2H > PT1H" "PT2H" "PT1H" (Just GT)
+            , check "P1M and P30D are incomparable (Nothing)"
+                "P1M" "P30D" Nothing
+            , check "P1M and P31D are incomparable" "P1M" "P31D" Nothing
+            , check "P1Y and P365D are incomparable (leap years)"
+                "P1Y" "P365D" Nothing
+            , check "-P1Y < P0D" "-P1Y" "P0D" (Just LT)
+            , check "P0D < P1Y" "P0D" "P1Y" (Just LT)
+            , check "P1Y > P0D" "P1Y" "P0D" (Just GT)
+            , check "PT1H1S > PT1H" "PT1H1S" "PT1H" (Just GT)
+            ]
+
+testOrd :: TestTree
+testOrd =
+    let
+        ds = map parseD
+            ["P0D", "P1Y", "P12M", "P30D", "P31D", "P1M", "PT1H", "PT3600S", "-P1Y", "P1Y2M3DT4H5M6S"]
+        reflexive d = compare d d == EQ
+        antisymmetric a b = case (compare a b, compare b a) of
+            (EQ, EQ) -> True
+            (LT, GT) -> True
+            (GT, LT) -> True
+            _ -> False
+        transitive a b c = case (compare a b, compare b c) of
+            (LT, LT) -> compare a c == LT
+            (GT, GT) -> compare a c == GT
+            (EQ, EQ) -> compare a c == EQ
+            _ -> True -- not constrained
+    in
+        nameTest
+            "Ord laws + XSD-consistency"
+            [ nameTest "reflexivity on sample" $
+                assertBool "" (all reflexive ds)
+            , nameTest "antisymmetry on all pairs" $
+                assertBool "" (and [antisymmetric a b | a <- ds, b <- ds])
+            , nameTest "transitivity on all triples" $
+                assertBool "" (and [transitive a b c | a <- ds, b <- ds, c <- ds])
+            , nameTest "Ord agrees with xsdCompare on strict orderings" $
+                -- When XSD says LT/GT, Ord must match; when XSD says
+                -- EQ or Nothing (incomparable), Ord uses the
+                -- structural tiebreaker — see haddock.
+                let pairs = [(a, b) | a <- ds, b <- ds]
+                    ok (a, b) = case xsdCompare a b of
+                        Just LT -> compare a b == LT
+                        Just GT -> compare a b == GT
+                        _ -> True
+                in assertBool "" (all ok pairs)
+            , nameTest "P1M and P30D get a deterministic order despite XSD incomparable" $
+                let r = compare (parseD "P1M") (parseD "P30D")
+                in assertBool ("expected /= EQ; got " ++ show r) (r /= EQ)
+            , nameTest "P1Y < P2Y" $
+                assertEqual "" LT (compare (parseD "P1Y") (parseD "P2Y"))
+            , nameTest "-P1Y < P0D < P1Y" $ do
+                assertEqual "" LT (compare (parseD "-P1Y") (parseD "P0D"))
+                assertEqual "" LT (compare (parseD "P0D") (parseD "P1Y"))
+            , nameTest "consistency with Eq: compare a b == EQ iff a == b" $
+                let pairs = [(a, b) | a <- ds, b <- ds]
+                    ok (a, b) = (compare a b == EQ) == (a == b)
+                in assertBool "" (all ok pairs)
+            ]
+
+testValueEqual :: TestTree
+testValueEqual =
+    let
+        check name a b expected =
+            nameTest name $
+                assertEqual "" expected (valueEqual (parseD a) (parseD b))
+    in
+        nameTest
+            "valueEqual (XSD 1.1 sec.3.3.6.1)"
+            [ check "P1Y == P12M (value)" "P1Y" "P12M" True
+            , check "P1W == P7D (value)" "P1W" "P7D" True
+            , check "PT1H == PT3600S (value)" "PT1H" "PT3600S" True
+            , check "PT1H == PT60M (value)" "PT1H" "PT60M" True
+            , check "P1Y /= P1M (value)" "P1Y" "P1M" False
+            , check "P1M /= P30D (value, distinct months/seconds)"
+                "P1M" "P30D" False
+            , nameTest "valueEqual is reflexive" $
+                assertBool "" (valueEqual (parseD "P1Y2M3DT4H5M6.7S") (parseD "P1Y2M3DT4H5M6.7S"))
+            , nameTest "structural Eq distinguishes P1Y and P12M" $
+                assertBool "" (parseD "P1Y" /= parseD "P12M")
+            ]
+
+testNFData :: TestTree
+testNFData =
+    let
+        forces x = (deepseq x ()) `seq` True
+    in
+        nameTest
+            "NFData"
+            [ nameTest "Duration forces" $
+                assertBool "" (forces (parseD "P1Y2M3DT4H5M6S"))
+            , nameTest "DurationDate (week) forces" $
+                assertBool "" (forces (durDate (parseD "P1W")))
+            , nameTest "zeroDuration forces" $
+                assertBool "" (forces zeroDuration)
+            ]
+
+testFormatTime :: TestTree
+testFormatTime =
+    let
+        d = parseD "P2Y3M4DT5H6M7S"
+    in
+        nameTest
+            "FormatTime instance"
+            [ nameTest "%y" $ assertEqual "" "2" (formatTime defaultTimeLocale "%y" d)
+            , nameTest "%B" $ assertEqual "" "3" (formatTime defaultTimeLocale "%B" d)
+            , nameTest "%b" $ assertEqual "" "27" (formatTime defaultTimeLocale "%b" d)
+            ]
+
+testXsdFormat :: TestTree
+testXsdFormat =
+    nameTest
+        "xsdDurationFormat (XSD 1.1 sec.3.3.6.2)"
+        [ nameTest "rejects PnW on read" $
+            assertEqual "" Nothing (formatParseM xsdDurationFormat "P1W" :: Maybe Duration)
+        , nameTest "rejects PnW on show" $
+            let weekDur = parseD "P1W"
+            in assertEqual "" Nothing (formatShowM xsdDurationFormat weekDur)
+        , nameTest "accepts P1Y2M3DT4H5M6S" $
+            assertEqual
+                ""
+                (Just "P1Y2M3DT4H5M6S")
+                (formatShowM xsdDurationFormat =<< (formatParseM xsdDurationFormat "P1Y2M3DT4H5M6S" :: Maybe Duration))
+        , nameTest "accepts leading sign (XSD prod. [15])" $
+            assertEqual
+                ""
+                (Just "-P1Y")
+                (formatShowM xsdDurationFormat =<< (formatParseM xsdDurationFormat "-P1Y" :: Maybe Duration))
+        ]
+
 testISO8601Duration :: TestTree
 testISO8601Duration =
     nameTest
         "Duration"
         [ testRoundTrip
         , testRejectInvalid
+        , testXSDLexicalEdges
+        , testFractionalSeconds
+        , testXSDCanonicalBounds
+        , testXSDSignDecomposition
+        , testAdditionNonCommutative
+        , testXsdRejectsAlternative
         , testToCalendarDiffTime
+        , testToCalendarDiffTimeSigns
+        , testFromCalendarDiffTime
+        , testZeroDuration
+        , testNormalize
+        , testSemigroup
+        , testSemigroupMore
+        , testScale
+        , testArithmetic
+        , testFormatTime
+        , testFormatTimeMore
+        , testXsdFormat
+        , testXsdCompare
+        , testOrd
+        , testValueEqual
+        , testDeprecatedAliases
+        , testNFData
         ]

--- a/test/main/Test/Format/Duration.hs
+++ b/test/main/Test/Format/Duration.hs
@@ -459,11 +459,27 @@ testSemigroupMore =
                 assertEqual "" expected (showD (parseD a <> parseD b))
     in
         nameTest
-            "Semigroup edge cases"
+            "Semigroup edge cases (XSD sec.3.3.6.1)"
             [ check "P1Y" "-P1Y" "P0D"
             , check "PT30M" "-PT15M" "PT15M"
             , check "P1Y6M" "P6M" "P2Y"
             , check "P1W" "P1W" "P14D"
+            , check "P0D" "P0D" "P0D"
+              -- Mixed-sign sum: months axis dominates, time
+              -- absorbed.  XSD §3.3.6.1 forbids mixed-sign in the
+              -- value space; the Semigroup picks the dominant axis.
+            , check "P1Y" "-PT1H" "P1Y"
+            , check "P2Y" "-P1M" "P1Y11M"
+              -- Mixed-sign sum: time axis dominates, months absorbed.
+            , check "P1M" "-P1Y" "-P11M"
+            , nameTest "matches CalendarDiffTime <> on same-signed sum" $
+                let a = parseD "P1Y2M3DT4H5M6S"
+                    b = parseD "P3Y4M5DT6H7M8S"
+                    sumD = a <> b
+                    sumCDT = toCalendarDiffTime a <> toCalendarDiffTime b
+                in assertEqual ""
+                    sumCDT
+                    (toCalendarDiffTime sumD)
             , nameTest "left identity" $
                 let d = parseD "P1Y2M3DT4H5M6.78S"
                 in assertEqual "" (normalizeDuration d) (mempty <> d)

--- a/time.cabal
+++ b/time.cabal
@@ -80,6 +80,7 @@ library
         Data.Time.LocalTime,
         Data.Time.Format,
         Data.Time.Format.ISO8601,
+        Data.Time.Format.ISO8601.Duration,
         Data.Time
     other-modules:
         Data.Format,
@@ -216,6 +217,7 @@ test-suite test-main
         Test.Clock.Resolution
         Test.Clock.TAI
         Test.Format.Compile
+        Test.Format.Duration
         Test.Format.Format
         Test.Format.ParseTime
         Test.Format.ISO8601


### PR DESCRIPTION
# Summary

`Data.Time.Format.ISO8601` parses ISO 8601 durations into
`CalendarDiffTime`, which stores only `(months :: Integer, time ::
NominalDiffTime)`.  The structured Y/M/W/D/H/M/S grammar is collapsed
at parse time, so `iso8601Show . iso8601ParseM` is **not** the
identity on perfectly valid ISO 8601 strings:

- `P1Y` and `P12M` → indistinguishable through `CalendarDiffTime`.
- `P1W` round-trips as `P7D`.
- `PT1H`, `PT60M`, `PT3600S` all collapse to the same value.

This is strictly required by **XML Schema `xs:duration`** (which
mandates lexical-space preservation) but is desirable in general:
JSON Schema, ICS/RFC 5545 `DURATION`, OData, and most REST APIs
quoting ISO 8601 expect the producer's chosen form to survive a
parse/serialize cycle.  An SLA expressed as `PT1H` in a contract
should not become `PT3600S` after a round-trip.

The new `Data.Time.Format.ISO8601.Duration` module provides a
structure-preserving `Duration` value that __may be used to replace
`CalendarDiffTime` for a significant gain in usability and
standards compliance__: bit-exact ISO 8601 / XSD round-trip, a
mixed-sign-free value space per XSD §3.3.6.1, an explicit XSD
partial-order comparison (`xsdCompare`), explicit value-equality
(`valueEqual`), and a documented total `Ord` that is monotone with
the spec.  Existing API is untouched; the deprecation arrows point
one way (toward `Duration`).

# Standards followed

Every public function cites the section it implements.  Summary
of the spec landscape:

- **ISO 8601:2004** §4.4.3.2 — designator form `P[nY][nM][nD][T[nH][nM][nS]]`
  and the week form `PnW` (mutually exclusive with the other
  designators).  §4.4.3.3 — alternative `Pyyyy-mm-ddThh:mm:ss` form.
  ISO 8601 forbids a leading sign on the designator form and permits
  a decimal fraction on the lowest-order component.
- **XSD 1.1 Part 2 Datatypes** §3.3.6 — `xs:duration`.  XSD diverges
  from ISO 8601 in three ways: it **admits a leading minus sign**
  (§3.3.6.2 prod. [15]), **omits the week form**, and **omits the
  alternative `Pyyyy-mm-dd...` form**.  Decimals are restricted to
  the seconds field (§3.3.6.2 prod. [11]).  Value space is the pair
  `(months, seconds)` with the invariant that the two components
  must not have opposite signs (§3.3.6.1).
- **XSD 1.1 §E.2** — `durationCanonicalMap`.  Months canonicalise as
  `(y, m) = (ym divMod 12)`; seconds canonicalise via successive
  division by 86400 / 3600 / 60.  Day count is **not** folded into
  months.  See `normalizeDuration`.
- **XSD 1.1 §E.3.3** — `dateTimePlusDuration`.  Months and seconds
  axes are added independently to a reference dateTime; the day
  field is then clipped before the seconds axis is folded in.  See
  `add{UTC,Local}DurationClip` / `*RollOver`.

# API

## Core type

```haskell
data DurationDate
  = DurationYMD   { ddYears, ddMonths, ddDays :: Maybe Integer }
  | DurationWeeks { ddWeeks :: Integer }

data Duration = Duration
  { durSign :: Integer            -- single leading sign per spec
  , durDate :: DurationDate
  , durTime :: Maybe (Maybe Integer, Maybe Integer, Maybe Pico)
  }
```

- Every field is `Maybe` so **absence** is distinguished from
  **zero**.  `P1Y` and `P0Y1M` round-trip to themselves rather than
  to a canonical form.
- `DurationDate` is a sum so the ISO 8601:2004 §4.4.3.2 rule that
  weeks are mutually exclusive with Y/M/D/T components is
  unrepresentable rather than runtime-checked.
- `durSign` carries the single whole-duration sign that ISO 8601 /
  XSD §3.3.6.2 prod. [15] permits.

## Formats

- `durationFormat :: Format Duration` — accepts both ISO 8601:2004
  §4.4.3.2 sub-forms (designator and week) and a leading sign
  (XSD prod. [15]).  Round-trips bit-exact.
- `xsdDurationFormat :: Format Duration` — strict XSD 1.1 subset:
  rejects `PnW` on read and show; otherwise identical.

## Bridging

```haskell
toCalendarDiffTime   :: Duration         -> CalendarDiffTime  -- total
fromCalendarDiffTime :: CalendarDiffTime -> Maybe Duration    -- partial
```

`fromCalendarDiffTime` is partial because `CalendarDiffTime` admits
mixed-sign values that XSD §3.3.6.1 forbids.  The result is in
canonical form per XSD §E.2 (so it never uses the week form).

## Normalization

```haskell
normalizeDuration :: Duration -> Duration
```

Implements `durationCanonicalMap` (XSD 1.1 §E.2): Y↔M carry on the
months axis, S→M→H→D carry on the time axis, no D→M (month length
is variable), zero fields dropped, week form folded to days, single
leading sign factored.  Idempotent.

### Arithmetic

```haskell
instance Semigroup Duration  -- spec-correct addition (XSD §3.3.6.1)
instance Monoid    Duration

scaleDuration             :: Integer -> Duration -> Duration

addUTCDurationClip        :: Duration -> UTCTime   -> UTCTime
addUTCDurationRollOver    :: Duration -> UTCTime   -> UTCTime
addLocalDurationClip      :: Duration -> LocalTime -> LocalTime
addLocalDurationRollOver  :: Duration -> LocalTime -> LocalTime
diffUTCDurationClip       :: UTCTime   -> UTCTime   -> Duration
diffUTCDurationRollOver   :: UTCTime   -> UTCTime   -> Duration
diffLocalDurationClip     :: LocalTime -> LocalTime -> Duration
diffLocalDurationRollOver :: LocalTime -> LocalTime -> Duration
```

Addition, scaling, and diffs all go through `CalendarDiffTime` and
return canonicalised results.  Structure preservation is for the
**lexical form** the user holds; arithmetic results are always in
canonical form (which is also XSD's only spec-mandated semantic).

The names mirror `CalendarDiffTime`'s.  `addDurationClip` /
`addDurationRollOver` from the initial commit are kept as
`DEPRECATED` aliases for `addUTCDurationClip` / `addUTCDurationRollOver`.

### Format-specifier support

`FormatTime Duration` instance, delegating to `CalendarDiffTime` via
`toCalendarDiffTime`.  All `%y`, `%b`, `%B` plus the inherited time
specifiers work.

### Comparison

```haskell
instance Ord Duration   -- total; monotone refinement of XSD
xsdCompare :: Duration -> Duration -> Maybe Ordering
valueEqual :: Duration -> Duration -> Bool
```

XSD 1.1 §3.3.6.1 specifies a /partial/ order on `xs:duration` —
`P1M` and `P30D` are genuinely incomparable.  Haskell's `Ord` is
total and conventionally consistent with `Eq`; both cannot hold
literally.  The compromise:

- `Ord` returns the XSD answer when XSD is strictly decisive
  (`xsdCompare` returns `Just LT` / `Just GT`).
- When XSD says equal-or-incomparable, `Ord` uses a deterministic
  structural tiebreaker (canonical `(months, seconds)` first, then
  show-form comparison), so `compare a b == EQ` iff `a == b`
  structurally.

The deviations are documented in the `Ord Duration` haddock and
the module-level "Spec deviations" section.

For the strict XSD partial order, use `xsdCompare` (returns
`Nothing` on genuinely incomparable pairs).  For XSD §3.3.6.1
value-equality (which structural `Eq` does not provide), use
`valueEqual`: `valueEqual P1Y P12M = True` but `P1Y /= P12M`.

# Demonstration

```
P1Y            round-trips to "P1Y"
P12M           round-trips to "P12M"
P1W            round-trips to "P1W"
P7D            round-trips to "P7D"
PT1H           round-trips to "PT1H"
PT60M          round-trips to "PT60M"
PT3600S        round-trips to "PT3600S"
P1Y2M3DT4H5M6S round-trips to "P1Y2M3DT4H5M6S"
PT1.5S         round-trips to "PT1.5S"
-P1Y           round-trips to "-P1Y"

P12M     normalizes to P1Y
P13M     normalizes to P1Y1M
P1W      normalizes to P7D
PT3600S  normalizes to PT1H
PT90.5S  normalizes to PT1M30.5S
P30D     normalizes to P30D     (D does NOT carry into M — XSD §E.2)

P1Y <> P12M    = P2Y
P1W <> P2D     = P9D
PT45M <> PT15M = PT1H

P              rejected
PT             rejected
P1W2D          rejected (week form excludes other date components)
```

# Summary of the files touched

- `lib/Data/Time/Format/ISO8601/Duration.hs` — main module
- `lib/Data/Time/Format/Format/Instances.hs` — `FormatTime Duration`
  instance (orphan, co-located with the other `FormatTime`
  instances)
- `time.cabal` — `Data.Time.Format.ISO8601.Duration` added to
  `exposed-modules`; `Test.Format.Duration` added to test
  `other-modules`
- `test/main/Test/Format/Duration.hs` — 39 HUnit cases
- `test/main/Main.hs` — wire `testISO8601Duration` into the suite

# Open to discussion

- **`Ord` is total but XML Schema's order is partial** — see the
  Comparison section above.  `xsdCompare` exposes the strict
  partial order; `Ord` adds a tiebreaker.
- **`xs:yearMonthDuration` (§3.4.26) and `xs:dayTimeDuration`
  (§3.4.27)** subset types are not implemented in this PR.  The
  PR is scoped to `xs:duration`; these are natural follow-ups.
- **`whiteSpace = collapse` facet (§3.3.6.3)** is not handled by
  the parser; XML toolchains typically collapse whitespace before
  passing values to the value-space parser, so this is a
  consumer-side concern.
- **No `POrd` / `PartialOrd` class adopted.** None is in `time`'s
  current dependency set; the `lattices` package's `PartialOrd`
  would be a new dep.  `xsdCompare` is exposed as a free function;
  adopting a class can be a follow-up if reviewers prefer.

# Backward compatibility

None affected.  `Duration` is a new type in a new module; the
existing `CalendarDiffTime` ISO 8601 instance, parser, and formatter
are unchanged.  `FormatTime CalendarDiffTime` is preserved verbatim;
`FormatTime Duration` is a new instance.

The `addDurationClip` / `addDurationRollOver` names from the initial
commit are kept as `{-# DEPRECATED #-}` aliases pointing at the new
`addUTCDurationClip` / `addUTCDurationRollOver`.

# Notes for reviewer

- `time.cabal` version field is **not** bumped (but desired) —
   the library release should be the maintainer's call.
- `Semigroup` / `Monoid` go through `toCalendarDiffTime` and
  `fromCalendarDiffTime` plus `normalizeDuration`.  Field-wise
  concatenation was rejected as a design — it's not associative or
  canonical, and it has no answer for `P1W <> P2D`.  The chosen
  semantics follows XML Schema §3.3.6.1, which is extension of ISO8601.
- Mixed-sign `CalendarDiffTime` values cannot arise from the sum of
  two same-signed `Duration`s.  When opposite-signed operands
  produce one (e.g. `P1Y <> -PT1H`), `Semigroup` keeps the
  dominant-magnitude axis and absorbs the smaller into zero — the
  closest representable approximation in the XSD value space (which
  forbids mixed-sign tuples per §3.3.6.1).  The same heuristic is
  used by `diff*Duration*` for diffs that produce mixed-sign
  intermediates.  For dateTime-anchored arithmetic, prefer
  `add{UTC,Local}Duration{Clip,RollOver}` (which apply XSD §E.3.3
  directly, with no mixed-sign question).  Open to a different
  policy here if the reviewer prefers.
- For same-signed operands the `Semigroup` is bit-exact equivalent
  to `CalendarDiffTime`'s `<>` via `toCalendarDiffTime` — explicitly
  asserted in tests.  This is what makes `Duration` a viable
  long-term replacement for `CalendarDiffTime` in arithmetic
  contexts.
- The `FormatTime Duration` orphan instance is co-located with the
  existing `FormatTime CalendarDiffTime` orphan in
  `Data.Time.Format.Format.Instances`, so users get it
  automatically wherever they import from `Data.Time.Format` or
  `Data.Time`.
- Discussion thread (open since 2014):
  <https://github.com/haskell/time/issues/40>.

Closes #292.